### PR TITLE
Add configuration for multipass.run

### DIFF
--- a/ingresses/production/multipass-run.yaml
+++ b/ingresses/production/multipass-run.yaml
@@ -1,0 +1,33 @@
+---
+
+kind: Ingress
+apiVersion: extensions/v1beta1  # See https://bit.ly/2KdOtrZ
+metadata:
+  name: multipass-run
+  namespace: production
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      if ($host != 'multipass.run' ) {
+        rewrite ^ https://multipass.run$request_uri? permanent;
+      }
+spec:
+  tls:
+  - secretName: multipass-run-tls
+    hosts:
+    - multipass.run
+    - www.multipass.run
+  rules:
+  - host: multipass.run
+    http: &multipass-run_service
+      paths:
+      - path: /
+        backend:
+          serviceName: multipass-run
+          servicePort: 80
+
+  # Alias domains
+  - host: www.multipass.run
+    http: *multipass-run_service
+
+---

--- a/ingresses/staging/staging-multipass-run.yaml
+++ b/ingresses/staging/staging-multipass-run.yaml
@@ -1,0 +1,26 @@
+---
+
+kind: Ingress
+apiVersion: extensions/v1beta1  # See https://bit.ly/2KdOtrZ
+metadata:
+  name: staging-multipass-run
+  namespace: staging
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      more_set_headers "X-Robots-Tag: noindex";
+spec:
+  tls:
+  - secretName: staging-multipass-run-tls
+    hosts:
+    - staging.multipass.run
+  rules:
+  - host: staging.multipass.run
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: multipass-run
+          servicePort: 80
+
+---

--- a/services/multipass-run.yaml
+++ b/services/multipass-run.yaml
@@ -1,0 +1,45 @@
+---
+
+kind: Service
+apiVersion: v1  # See https://bit.ly/2KdOtrZ
+metadata:
+  name: multipass-run
+spec:
+  selector:
+    app: multipass.run
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: http
+
+---
+
+kind: Deployment
+apiVersion: extensions/v1beta1  # See https://bit.ly/2KdOtrZ
+metadata:
+  name: multipass-run
+spec:
+  replicas: 5
+  template:
+    metadata:
+      labels:
+        app: multipass.run
+    spec:
+      containers:
+        - name: multipass-run
+          image: prod-comms.docker-registry.canonical.com/multipass.run:${TAG_TO_DEPLOY}
+          ports:
+            - name: http
+              containerPort: 80
+          readinessProbe:
+            httpGet:
+              path: /_status/check
+              port: 80
+            timeoutSeconds: 3
+            periodSeconds: 5
+          resources:
+            limits:
+              memory: "256Mi"
+
+---


### PR DESCRIPTION
# Summary

Fixes https://github.com/canonical-web-and-design/base-squad/issues/486 
Add configuration for multipass.run

# QA 

- `./qa-deploy --production multipass.run --tag test`
- `curl -I -H 'Host: multipass.run' 127.0.0.1`
- Make sure it 200s
- You can add the host in your `/etc/hosts` and make sure that you can navigate the site
