### PR TITLE
Add noindex to old-docs.jujucharms.com

### DIFF
--- a/ingresses/production/old-docs-jujucharms-com.yaml
+++ b/ingresses/production/old-docs-jujucharms-com.yaml
@@ -7,6 +7,8 @@ metadata:
   namespace: production
   annotations:
     kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      more_set_headers "X-Robots-Tag: noindex";
 spec:
   tls:
   - secretName: old-docs-jujucharms-com-tls


### PR DESCRIPTION
Fixes https://github.com/canonical-web-and-design/base-squad/issues/491

QA
--

``` bash
./qa-deploy --production old-docs.jujucharms.com --tag latest
```

Then, once it's deployed:

``` bash
curl -I -H 'Host: old-docs.jujucharms.com' 127.0.0.1
```

And check you see `X-Robots-Tag: noindex` in the output.