### PR TITLE
Make ingress for ubuntu-com.internal

### DIFF
--- a/ingresses/production/ubuntu-com-internal.yaml
+++ b/ingresses/production/ubuntu-com-internal.yaml
@@ -1,29 +1,25 @@
 ---
 
 kind: Ingress
-apiVersion: extensions/v1beta1
+apiVersion: extensions/v1beta1  # See https://bit.ly/2KdOtrZ
 metadata:
-  name: ubuntu-com
+  name: ubuntu-com-internal
   namespace: production
   annotations:
     kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/configuration-snippet: |
-      if ($host != 'ubuntu.com' ) {
+      if ($host = 'www.ubuntu.com' ) {
         rewrite ^ https://ubuntu.com$request_uri? permanent;
       }
 
 spec:
   rules:
-  - host: ubuntu.com
-    http: &ubuntu-com_service
+  - host: ubuntu-com.internal
+    http:
       paths:
       - path: /
         backend:
           serviceName: ubuntu-com
           servicePort: 80
-
-  # Alias domains
-  - host: www.ubuntu.com
-    http: *ubuntu-com_service
 
 ---

--- a/services/ubuntu-com.yaml
+++ b/services/ubuntu-com.yaml
@@ -32,18 +32,22 @@ spec:
           ports:
             - name: http
               containerPort: 80
+          envFrom:
+            - configMapRef:
+                name: proxy-config
+                optional: true
+          env:
+            - name: SEARCH_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: google-api
+                  key: google-custom-search-key
           readinessProbe:
             httpGet:
               path: /_status/check
               port: 80
             timeoutSeconds: 3
             periodSeconds: 5
-          env:
-            - name: SEARCH_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: google-api
-                  key: search-api-key
           resources:
             limits:
               memory: "256Mi"


### PR DESCRIPTION
Following on from [the architecture plan](https://docs.google.com/document/d/1v_0aAp936Sx85QNNF4iTxoAhRSbuc4iplxDXg8hkWxo/edit), this should expose ubuntu-com.internal for consumption by squid.

Fixes https://github.com/canonical-web-and-design/base-squad/issues/502

QA
--

``` bash
microk8s.start && microk8s.reset  # Make sure microk8s is ready
sed -i 's!301!"301"!' config.global.yaml  # Use microk8s-compatible format
microk8s.kubectl create secret generic google-api --from-literal=google-custom-search-key='notsosecret'  # create a fake secret
./qa-deploy --production ubuntu-com --tag latest  # allow it to fail
cat ingresses/production/ubuntu-com-internal.yaml | sed '/namespace:/d' | microk8s.kubectl apply -f -
watch microk8s.kubectl get all,ingress
```

^ When everything is spun up, and you can see "127.0.0.1" under the ingress, try:

``` bash
curl -I -H 'Host: ubuntu-com.internal' http://127.0.0.1
```

Check you see:

``` bash
X-Hostname: ubuntu-com-f7f5ddc4c-kjbw7
X-VCS-Revision: 1557488685-0c384e1
```