### PR TITLE
Configs for releases.demo.haus

### DIFF
--- a/ingresses/staging/releases-demo-haus.yaml
+++ b/ingresses/staging/releases-demo-haus.yaml
@@ -1,0 +1,22 @@
+---
+
+kind: Ingress
+apiVersion: extensions/v1beta1  # See https://bit.ly/2KdOtrZ
+metadata:
+  name: releases-demo-haus
+  namespace: staging
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      more_set_headers "X-Robots-Tag: noindex";
+spec:
+  rules:
+  - host: releases.demo.haus
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: releases-demo-haus
+          servicePort: 80
+
+---

--- a/services/releases-demo-haus.yaml
+++ b/services/releases-demo-haus.yaml
@@ -1,0 +1,45 @@
+---
+
+kind: Service
+apiVersion: v1
+metadata:
+  name: releases-demo-haus
+spec:
+  selector:
+    app: releases.demo.haus
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: http
+
+---
+
+kind: Deployment
+apiVersion: extensions/v1beta1
+metadata:
+  name: releases-demo-haus
+spec:
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        app: releases-demo-haus
+    spec:
+      containers:
+        - name: releases-demo-haus
+          image: prod-comms.docker-registry.canonical.com/releases.demo.haus:${TAG_TO_DEPLOY}
+          ports:
+            - name: http
+              containerPort: 80
+          readinessProbe:
+            httpGet:
+              path: /_status/check
+              port: 80
+            timeoutSeconds: 3
+            periodSeconds: 5
+          resources:
+            limits:
+              memory: "128Mi"
+
+---


### PR DESCRIPTION
This deploys http://releases.demo.haus into the "staging" namespace.

QA
--


``` bash
microk8s.start && microk8s.reset  # Make sure microk8s is ready
sed -i 's!301!"301"!' config.global.yaml  # Use microk8s-compatible format
./qa-deploy --production releases.demo.haus --tag latest  # allow it to fail
cat ingresses/staging/releases-demo-haus.yaml | sed '/namespace:/d' | microk8s.kubectl apply -f -
watch microk8s.kubectl get all,ingress
```

^ When everything is spun up, and you can see "127.0.0.1" under the ingress, try:

``` bash
curl -I -H 'Host: releases.demo.haus' http://127.0.0.1
```