### PR TITLE
Add proxy to canonical.com

### DIFF
--- a/services/canonical-com.yaml
+++ b/services/canonical-com.yaml
@@ -32,6 +32,10 @@ spec:
           ports:
             - name: http
               containerPort: 80
+          envFrom:
+            - configMapRef:
+                name: proxy-config
+                optional: true
           readinessProbe:
             httpGet:
               path: /_status/check


### PR DESCRIPTION
# Summary

Add proxy to canonical.com to make sure greenhouse api calls work.

# QA

- `./qa-deploy --production canonical.com --tag latest`
- make sure pod has the right env var.