### PR TITLE
Change ReadnessProbe from / to /_status/check

### DIFF
--- a/services/canonical-com.yaml
+++ b/services/canonical-com.yaml
@@ -34,7 +34,7 @@ spec:
               containerPort: 80
           readinessProbe:
             httpGet:
-              path: /
+              path: /_status/check
               port: 80
             timeoutSeconds: 3
             periodSeconds: 5


### PR DESCRIPTION
# Summary

Fixes https://github.com/canonical-web-and-design/base-squad/issues/564
This configuration hasn't been updated yet:
- Change ReadnessProbe from / to /_status/check

# QA

- `./qa-deploy --production canonical.com --tag latest`
- Check the logs of the pod deployed and make sure the `/_status/check` is well called
> The image uploaded is old so you will have also `django.request` that will 404 on this endpoint. It not a problem since talisker returns well and that we are converting the site to flask. If you have a doubt access: canonical.com/_status/check and check that django.request creates that log.