### PR TITLE
Handle [www.]microk8s.com

### DIFF
--- a/ingresses/production/microk8s-io.yaml
+++ b/ingresses/production/microk8s-io.yaml
@@ -17,6 +17,10 @@ spec:
     hosts:
     - microk8s.io
     - www.microk8s.io
+  - secretName: microk8s-com-tls
+    hosts:
+    - microk8s.com
+    - www.microk8s.com
   rules:
   - host: microk8s.io
     http: &microk8s_service
@@ -28,6 +32,14 @@ spec:
 
   # Alias domains
   - host: www.microk8s.io
+    http: *microk8s_service
+
+  # Alias domains
+  - host: microk8s.com
+    http: *microk8s_service
+
+  # Alias domains
+  - host: www.microk8s.com
     http: *microk8s_service
 
 ---


### PR DESCRIPTION
Listen for www.microk8s.com and microk8s.com, and allow them to be redirected to the primary domain, microk8s.io.