### PR TITLE
Disable "includeSubdomains" in HSTS

### DIFF
--- a/config.global.yaml
+++ b/config.global.yaml
@@ -3,6 +3,9 @@ data:
   body-size: "0"
   # Change redirect code to 301 as 308 is not understood by social media bots
   http-redirect-code: 301
+  # We can't include subdomains for canonical.com
+  # It only seems possible to set this globally
+  hsts-include-subdomains: "false"
   map-hash-bucket-size: "128"
   proxy-body-size: "0"
   proxy-buffer-size: "8k"

--- a/qa-deploy
+++ b/qa-deploy
@@ -59,8 +59,8 @@ function apply_configuration() {
 
     # On the version of the ingress controller we have we need to change the
     # name to be able to apply the configuration. By default the nginx ingress
-    # controller is searching for a config-map called: nginx-load-balancer-conf
-    cat "config.global.yaml" | sed 's|name: nginx-configuration|name: nginx-load-balancer-conf|' | microk8s.kubectl apply --filename - --namespace default
+    # controller is searching for a config-map called: nginx-load-balancer-microk8s-conf
+    cat "config.global.yaml" | sed 's|name: nginx-configuration|name: nginx-load-balancer-microk8s-conf|' | microk8s.kubectl apply --filename - --namespace default
 }
 
 function run_microk8s() {


### PR DESCRIPTION
This disables the "includeSubDomains" setting in HSTS for all domains, even
though the only one where we really *need* to turn it off is actually
canonical.com.

However, after much searching, there doesn't appear to be any way to turn
off "includeSubDomains" on a per-ingress level.

If we really wanted all other sites to have "includeSubDomains", but turn
it off only in canonical.com, the only way to achieve it would be to turn
HSTS off globally (`hsts: "false"`), and then manually add the
`strict-transport-security` to every ingress via config snippets.

This seems more risky, as we could easily forget to enable it for a domain,
and certainly more cumbersome. On balance, the
"includeSubDomains" setting isn't very important for most domains, and
arguably dangerous for some, so in the circumstances it's probably best to
simply disable it globally.

If Kubernetes add the ability to trivially tweak the setting at the ingress
level, we may change this global setting in the future.

This is to address the issue raised in RT #119081.

QA
--

``` bash
$ ./qa-deploy --production canonical.com --tag latest
# ... wait for a while
$ curl -I -H 'Host: canonical.com' --insecure https://127.0.0.1
...
strict-transport-security: max-age=15724800
```

^ Check there is no "includeSubDomains" in the `strict-transport-security` header.