### PR TITLE
Add sentry env var to ubuntu.com

### DIFF
--- a/services/ubuntu-com.yaml
+++ b/services/ubuntu-com.yaml
@@ -42,6 +42,11 @@ spec:
                 secretKeyRef:
                   name: google-api
                   key: google-custom-search-key
+            - name: SENTRY_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: sentry-dsn
+                  key: ubuntu-com
           readinessProbe:
             httpGet:
               path: /_status/check


### PR DESCRIPTION
# SUmmary

Add sentry to ubuntu.com

# QA

- [ ] Create google API secret: `microk8s.kubectl create secret generic google-api --from-literal=google-custom-search-key='notsosecret'`
- [ ] Create sentry DSN secret: `microk8s.kubectl create secret generic sentry-dsn --from-literal=ubuntu-com='notsosecret'`
- [ ] `./qa-deploy --production ubuntu.com --tag latest`
- [ ] Run `microk8s.kubectl exec $(microk8s.kubectl get pod --output json --selector app=ubuntu.com | jq -r '.items[0].metadata.name') env | grep SENTRY_DSN` - check SENTRY_DSN is set: `SENTRY_DSN=something`
