### PR TITLE
Configs for old-docs.maas.io

### DIFF
--- a/ingresses/production/old-docs-maas-io.yaml
+++ b/ingresses/production/old-docs-maas-io.yaml
@@ -1,0 +1,36 @@
+---
+
+kind: Ingress
+apiVersion: extensions/v1beta1
+metadata:
+  name: old-docs-maas-io
+  namespace: production
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      more_set_headers "X-Robots-Tag: noindex";
+      if ($host != 'old-docs.maas.io' ) {
+        rewrite ^ https://docs.maas.io$request_uri? permanent;
+      }
+spec:
+  tls:
+  - secretName: old-docs-maas-io-tls
+    hosts:
+    - old-docs.maas.io
+  - secretName: docs-maas-io-tls
+    hosts:
+    - docs.maas.io
+  rules:
+  - host: old-docs.maas.io
+    http: &old-docs-maas-io_service
+      paths:
+      - path: /
+        backend:
+          serviceName: old-docs-maas-io
+          servicePort: 80
+
+  # Alias domains
+  # - host: docs.staging.maas.io
+  #   http: *old-docs-maas-io_service
+
+---

--- a/ingresses/staging/old-docs-staging-maas-io.yaml
+++ b/ingresses/staging/old-docs-staging-maas-io.yaml
@@ -1,0 +1,36 @@
+---
+
+kind: Ingress
+apiVersion: extensions/v1beta1
+metadata:
+  name: docs-staging-maas-io
+  namespace: staging
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      more_set_headers "X-Robots-Tag: noindex";
+      if ($host != 'old-docs.staging.maas.io' ) {
+        rewrite ^ https://docs.staging.maas.io$request_uri? permanent;
+      }
+spec:
+  tls:
+  - secretName: old-docs-staging-maas-io-tls
+    hosts:
+    - old-docs.staging.maas.io
+  - secretName: docs-staging-maas-io-tls
+    hosts:
+    - docs.staging.maas.io
+  rules:
+  - host: old-docs.staging.maas.io
+    http: &old-docs-maas-io_service
+      paths:
+      - path: /
+        backend:
+          serviceName: old-docs-maas-io
+          servicePort: 80
+
+  # Alias domains
+  # - host: docs.staging.maas.io
+  #   http: *old-docs-maas-io_service
+
+---

--- a/services/old-docs-maas-io.yaml
+++ b/services/old-docs-maas-io.yaml
@@ -1,0 +1,45 @@
+---
+
+kind: Service
+apiVersion: v1
+metadata:
+  name: old-docs-maas-io
+spec:
+  selector:
+    app: old-docs.maas.io
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: http
+
+---
+
+kind: Deployment
+apiVersion: extensions/v1beta1
+metadata:
+  name: old-docs-maas-io
+spec:
+  replicas: 5
+  template:
+    metadata:
+      labels:
+        app: old-docs.maas.io
+    spec:
+      containers:
+        - name: old-docs-maas-io
+          image: prod-comms.docker-registry.canonical.com/old-docs.maas.io:${TAG_TO_DEPLOY}
+          ports:
+            - name: http
+              containerPort: 80
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            timeoutSeconds: 3
+            periodSeconds: 5
+          resources:
+            limits:
+              memory: "256Mi"
+
+---


### PR DESCRIPTION
For now I've commented out the host alias for docs.maas.io, as we're not ready to turn that domain off yet.

QA
--

``` bash
./qa-deploy --production old-docs.maas.io --staging old-docs.staging.maas.io --tag 1561024397-64d73a4
watch microk8s.kubectl get all,ingress
```

After things have spun up, IP addresses assigned to ingresses etc., then do:

```
$ curl -I -H 'Host: old-docs.maas.io' --insecure https://127.0.0.1/2.5/en/
$ curl -I -H 'Host: old-docs.staging.maas.io' --insecure https://127.0.0.1/2.5/en/
```

Check you see 200s.