### PR TITLE
Redirect insights.ubuntu.com to ubuntu.com/blog

### DIFF
--- a/ingresses/production/ubuntu-com.yaml
+++ b/ingresses/production/ubuntu-com.yaml
@@ -8,6 +8,9 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/configuration-snippet: |
+      if ($host = 'insights.ubuntu.com' ) {
+        rewrite ^ https://ubuntu.com/blog$request_uri? permanent;
+      }
       if ($host = 'blog.ubuntu.com' ) {
         rewrite ^ https://ubuntu.com/blog$request_uri? permanent;
       }
@@ -20,6 +23,9 @@ spec:
   - secretName: blog-ubuntu-com-tls
     hosts:
     - blog.ubuntu.com
+  - secretName: insights-ubuntu-com-tls
+    hosts:
+    - insights.ubuntu.com
   rules:
   - host: ubuntu.com
     http: &ubuntu-com_service
@@ -45,6 +51,8 @@ spec:
   - host: www.ubuntulinux.org
     http: *ubuntu-com_service
   - host: blog.ubuntu.com
+    http: *ubuntu-com_service
+  - host: insights.ubuntu.com
     http: *ubuntu-com_service
 
 ---


### PR DESCRIPTION
The old blog-ubuntu-com ingress used to redirect insights.ubuntu.com
as well. We should preserve this in the ubuntu-com ingress.

QA
--

``` bash
$ ./qa-deploy --production ubuntu.com --tag latest
```

When things have spun up:

``` bash
$ curl -I -H 'Host: insights.ubuntu.com' --insecure https://127.0.0.1/
HTTP/2 301 
server: nginx/1.15.8
date: Mon, 24 Jun 2019 08:26:44 GMT
content-type: text/html
content-length: 169
location: https://ubuntu.com/blog/
```