### PR TITLE
Revert /blog redirect work for now

### DIFF
--- a/ingresses/production/blog-ubuntu-com.yaml
+++ b/ingresses/production/blog-ubuntu-com.yaml
@@ -1,0 +1,35 @@
+---
+
+kind: Ingress
+apiVersion: extensions/v1beta1
+metadata:
+  name: blog-ubuntu-com
+  namespace: production
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      if ($host != 'blog.ubuntu.com' ) {
+        rewrite ^ https://blog.ubuntu.com$request_uri? permanent;
+      }
+spec:
+  tls:
+  - secretName: blog-ubuntu-com-tls
+    hosts:
+    - blog.ubuntu.com
+  - secretName: insights-ubuntu-com-tls
+    hosts:
+    - insights.ubuntu.com
+  rules:
+  - host: blog.ubuntu.com
+    http: &blog-ubuntu-com_service
+      paths:
+      - path: /
+        backend:
+          serviceName: blog-ubuntu-com
+          servicePort: 80
+
+  # Alias domains
+  - host: insights.ubuntu.com
+    http: *blog-ubuntu-com_service
+
+---

--- a/ingresses/production/ubuntu-com.yaml
+++ b/ingresses/production/ubuntu-com.yaml
@@ -8,18 +8,11 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/configuration-snippet: |
-      if ($host = 'blog.ubuntu.com' ) {
-        rewrite ^ https://ubuntu.com/blog$request_uri? permanent;
-      }
       if ($host != 'ubuntu.com' ) {
         rewrite ^ https://ubuntu.com$request_uri? permanent;
       }
 
 spec:
-  tls:
-  - secretName: blog-ubuntu-com-tls
-    hosts:
-    - blog.ubuntu.com
   rules:
   - host: ubuntu.com
     http: &ubuntu-com_service
@@ -43,8 +36,6 @@ spec:
   - host: ubuntulinux.org
     http: *ubuntu-com_service
   - host: www.ubuntulinux.org
-    http: *ubuntu-com_service
-  - host: blog.ubuntu.com
     http: *ubuntu-com_service
 
 ---

--- a/ingresses/production/ubuntu-com.yaml
+++ b/ingresses/production/ubuntu-com.yaml
@@ -8,9 +8,6 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/configuration-snippet: |
-      if ($host = 'insights.ubuntu.com' ) {
-        rewrite ^ https://ubuntu.com/blog$request_uri? permanent;
-      }
       if ($host = 'blog.ubuntu.com' ) {
         rewrite ^ https://ubuntu.com/blog$request_uri? permanent;
       }
@@ -23,9 +20,6 @@ spec:
   - secretName: blog-ubuntu-com-tls
     hosts:
     - blog.ubuntu.com
-  - secretName: insights-ubuntu-com-tls
-    hosts:
-    - insights.ubuntu.com
   rules:
   - host: ubuntu.com
     http: &ubuntu-com_service
@@ -51,8 +45,6 @@ spec:
   - host: www.ubuntulinux.org
     http: *ubuntu-com_service
   - host: blog.ubuntu.com
-    http: *ubuntu-com_service
-  - host: insights.ubuntu.com
     http: *ubuntu-com_service
 
 ---

--- a/ingresses/staging/blog-staging-ubuntu-com.yaml
+++ b/ingresses/staging/blog-staging-ubuntu-com.yaml
@@ -1,0 +1,34 @@
+---
+
+kind: Ingress
+apiVersion: extensions/v1beta1
+metadata:
+  name: blog-staging-ubuntu-com
+  namespace: staging
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      more_set_headers "X-Robots-Tag: noindex";
+      if ($host != 'blog.staging.ubuntu.com' ) {
+        rewrite ^ https://blog.staging.ubuntu.com$request_uri? permanent;
+      }
+spec:
+  tls:
+  - secretName: blog-staging-ubuntu-com-tls
+    hosts:
+    - blog.staging.ubuntu.com
+  - secretName: insights-staging-ubuntu-com-tls
+    hosts:
+    - insights.staging.ubuntu.com
+  rules:
+  - host: blog.staging.ubuntu.com
+    http: &blog-ubuntu-com_service
+      paths:
+      - path: /
+        backend:
+          serviceName: blog-ubuntu-com
+          servicePort: 80
+  - host: insights.staging.ubuntu.com
+    http: *blog-ubuntu-com_service
+
+---

--- a/ingresses/staging/staging-ubuntu-com.yaml
+++ b/ingresses/staging/staging-ubuntu-com.yaml
@@ -9,9 +9,6 @@ metadata:
     kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/configuration-snippet: |
       more_set_headers "X-Robots-Tag: noindex";
-      if ($host = 'blog.staging.ubuntu.com' ) {
-        rewrite ^ https://staging.ubuntu.com/blog$request_uri? permanent;
-      }
       if ($host != 'staging.ubuntu.com' ) {
         rewrite ^ https://staging.ubuntu.com$request_uri? permanent;
       }
@@ -20,9 +17,6 @@ spec:
   - secretName: staging-ubuntu-com-tls
     hosts:
     - staging.ubuntu.com
-  - secretName: blog-staging-ubuntu-com-tls
-    hosts:
-    - blog.staging.ubuntu.com
   rules:
   - host: staging.ubuntu.com
     http: &ubuntu-com_service
@@ -34,8 +28,6 @@ spec:
   
   # Alias domains
   - host: www.staging.ubuntu.com
-    http: *ubuntu-com_service
-  - host: blog.staging.ubuntu.com
     http: *ubuntu-com_service
 
 ---

--- a/services/blog-ubuntu-com.yaml
+++ b/services/blog-ubuntu-com.yaml
@@ -1,0 +1,51 @@
+---
+
+kind: Service
+apiVersion: v1
+metadata:
+  name: blog-ubuntu-com
+spec:
+  selector:
+    app: blog.ubuntu.com
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: http
+
+---
+
+kind: Deployment
+apiVersion: extensions/v1beta1
+metadata:
+  name: blog-ubuntu-com
+spec:
+  replicas: 5
+  template:
+    metadata:
+      labels:
+        app: blog.ubuntu.com
+    spec:
+      containers:
+        - name: blog-ubuntu-com
+          image: prod-comms.docker-registry.canonical.com/blog.ubuntu.com:${TAG_TO_DEPLOY}
+          ports:
+            - name: http
+              containerPort: 80
+          env:
+            - name: SENTRY_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: sentry-dsn
+                  key: blog-ubuntu-com
+          readinessProbe:
+            httpGet:
+              path: /_status/check
+              port: 80
+            timeoutSeconds: 3
+            periodSeconds: 5
+          resources:
+            limits:
+              memory: "256Mi"
+
+---


### PR DESCRIPTION
This caused a redirect loop in production.

This change has already gone live. Incident report: https://wiki.canonical.com/IncidentReports/2019-06-24-Ubuntu.com%20ingress%20redirect%20loop