### PR TITLE
Add HTTP[S]_PROXY and google api key to maas.io

### DIFF
--- a/services/maas-io.yaml
+++ b/services/maas-io.yaml
@@ -32,12 +32,21 @@ spec:
           ports:
             - name: http
               containerPort: 80
+          envFrom:
+            - configMapRef:
+                name: proxy-config
+                optional: true
           env:
             - name: SENTRY_DSN
               valueFrom:
                 secretKeyRef:
                   name: sentry-dsn
                   key: maas-io
+            - name: SEARCH_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: google-api
+                  key: google-custom-search-key
           readinessProbe:
             httpGet:
               path: /_status/check


### PR DESCRIPTION
# Summary

- Add proxy to maas.io (for the docs)
- Add google api key to be able to add search on docs.

# QA

- `microk8s.kubectl create secret generic google-api --from-literal=google-custom-search-key='notsosecret'`
- `./qa-deploy --production maas.io --tag latest`
- Make sure pods have the secrets `HTTP_PROXY`, `HTTPS_PROXY` and `SEARCH_API_KEY` set as env var.