### PR TITLE
Add google search API key to snapcraft-io

### DIFF
--- a/services/snapcraft-io.yaml
+++ b/services/snapcraft-io.yaml
@@ -92,6 +92,11 @@ spec:
                 secretKeyRef:
                   name: snapcraft-io-config
                   key: marketo_client_secret
+            - name: SEARCH_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: google-api
+                  key: google-custom-search-key
           readinessProbe:
             httpGet:
               path: /_status/check


### PR DESCRIPTION
# Done
Adds environment variable to the snapcraft-io service, that contains the google search API key.