### PR TITLE
Disable HTTP2 for main NGINX controller

### DIFF
--- a/config.global.yaml
+++ b/config.global.yaml
@@ -10,6 +10,7 @@ data:
   proxy-body-size: "0"
   proxy-buffer-size: "8k"
   proxy-buffers: "4 8k"
+  use-http2: "false"
 kind: ConfigMap
 metadata:
   name: nginx-configuration


### PR DESCRIPTION
Disables HTTP2

## QA

- `./qa-deploy --production snapcraft.io --tag latest`
- `curl -I -H 'Host: snapcraft.io' --insecure https://127.0.0.1/` and make sure it's using HTTP1.1
- change the `use-http2 setting` to `true`
- `./qa-deploy --production snapcraft.io --tag latest`
- `curl -I -H 'Host: snapcraft.io' --insecure https://127.0.0.1/` and make sure it's using HTTP2