### PR TITLE
Configs for certification.ubuntu.com, dqlite.io and etclite.io

### DIFF
--- a/ingresses/production/certification-ubuntu-com.yaml
+++ b/ingresses/production/certification-ubuntu-com.yaml
@@ -1,0 +1,24 @@
+---
+
+kind: Ingress
+apiVersion: extensions/v1beta1  # See https://bit.ly/2KdOtrZ
+metadata:
+  name: certification-ubuntu-com
+  namespace: production
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+spec:
+  tls:
+  - secretName: certification-ubuntu-com-tls
+    hosts:
+    - certification.ubuntu.com
+  rules:
+  - host: certification.ubuntu.com
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: certification-ubuntu-com
+          servicePort: 80
+
+---

--- a/ingresses/production/dqlite-io.yaml
+++ b/ingresses/production/dqlite-io.yaml
@@ -1,0 +1,33 @@
+---
+
+kind: Ingress
+apiVersion: extensions/v1beta1  # See https://bit.ly/2KdOtrZ
+metadata:
+  name: dqlite-io
+  namespace: production
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      if ($host != 'dqlite.io' ) {
+        rewrite ^ https://dqlite.io$request_uri? permanent;
+      }
+spec:
+  tls:
+  - secretName: dqlite-io-tls
+    hosts:
+    - dqlite.io
+    - www.dqlite.io
+  rules:
+  - host: dqlite.io
+    http: &dqlite-io_service
+      paths:
+      - path: /
+        backend:
+          serviceName: dqlite-io
+          servicePort: 80
+
+  # Alias domains
+  - host: www.dqlite.io
+    http: *dqlite-io_service
+
+---

--- a/ingresses/production/etclite-io.yaml
+++ b/ingresses/production/etclite-io.yaml
@@ -1,0 +1,33 @@
+---
+
+kind: Ingress
+apiVersion: extensions/v1beta1  # See https://bit.ly/2KdOtrZ
+metadata:
+  name: etclite-io
+  namespace: production
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      if ($host != 'etclite.io' ) {
+        rewrite ^ https://etclite.io$request_uri? permanent;
+      }
+spec:
+  tls:
+  - secretName: etclite-io-tls
+    hosts:
+    - etclite.io
+    - www.etclite.io
+  rules:
+  - host: etclite.io
+    http: &etclite-io_service
+      paths:
+      - path: /
+        backend:
+          serviceName: etclite-io
+          servicePort: 80
+
+  # Alias domains
+  - host: www.etclite.io
+    http: *etclite-io_service
+
+---

--- a/ingresses/staging/certification-staging-ubuntu-com.yaml
+++ b/ingresses/staging/certification-staging-ubuntu-com.yaml
@@ -1,0 +1,26 @@
+---
+
+kind: Ingress
+apiVersion: extensions/v1beta1  # See https://bit.ly/2KdOtrZ
+metadata:
+  name: certification-staging-ubuntu-com
+  namespace: staging
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      more_set_headers "X-Robots-Tag: noindex";
+spec:
+  tls:
+  - secretName: certification-staging-ubuntu-com-tls
+    hosts:
+    - certification.staging.ubuntu.com
+  rules:
+  - host: certification.staging.ubuntu.com
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: certification-ubuntu-com
+          servicePort: 80
+
+---

--- a/ingresses/staging/staging-dqlite-io.yaml
+++ b/ingresses/staging/staging-dqlite-io.yaml
@@ -1,0 +1,26 @@
+---
+
+kind: Ingress
+apiVersion: extensions/v1beta1  # See https://bit.ly/2KdOtrZ
+metadata:
+  name: staging-dqlite-io
+  namespace: staging
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      more_set_headers "X-Robots-Tag: noindex";
+spec:
+  tls:
+  - secretName: staging-dqlite-io-tls
+    hosts:
+    - staging.dqlite.io
+  rules:
+  - host: staging.dqlite.io
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: dqlite-io
+          servicePort: 80
+
+---

--- a/ingresses/staging/staging-etclite-io.yaml
+++ b/ingresses/staging/staging-etclite-io.yaml
@@ -1,0 +1,26 @@
+---
+
+kind: Ingress
+apiVersion: extensions/v1beta1  # See https://bit.ly/2KdOtrZ
+metadata:
+  name: staging-etclite-io
+  namespace: staging
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      more_set_headers "X-Robots-Tag: noindex";
+spec:
+  tls:
+  - secretName: staging-etclite-io-tls
+    hosts:
+    - staging.etclite.io
+  rules:
+  - host: staging.etclite.io
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: etclite-io
+          servicePort: 80
+
+---

--- a/qa-deploy
+++ b/qa-deploy
@@ -43,6 +43,9 @@ function add_secrets() {
         microk8s.kubectl create secret generic sentry-dsn \
             --from-literal=kubeflow-news-com='https://public:private@host:8000/1' \
             --from-literal=maas-io='https://public:private@host:8000/1'  \
+            --from-literal=certification-ubuntu-com='https://public:private@host:8000/1'  \
+            --from-literal=dqlite-io='https://public:private@host:8000/1'  \
+            --from-literal=etclite-io='https://public:private@host:8000/1'  \
             --from-literal=jaas-ai-com='https://public:private@host:8000/1'  \
             --from-literal=canonical-com='https://public:private@host:8000/1'  \
             --from-literal=docs-snapcraft-io='https://public:private@host:8000/1'  \

--- a/services/certification-ubuntu-com.yaml
+++ b/services/certification-ubuntu-com.yaml
@@ -1,0 +1,45 @@
+---
+
+kind: Service
+apiVersion: v1  # See https://bit.ly/2KdOtrZ
+metadata:
+  name: certification-ubuntu-com
+spec:
+  selector:
+    app: certification.ubuntu.com
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: http
+
+---
+
+kind: Deployment
+apiVersion: extensions/v1beta1  # See https://bit.ly/2KdOtrZ
+metadata:
+  name: certification-ubuntu-com
+spec:
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        app: certification.ubuntu.com
+    spec:
+      containers:
+        - name: certification-ubuntu-com
+          image: prod-comms.docker-registry.canonical.com/certification.ubuntu.com:${TAG_TO_DEPLOY}
+          ports:
+            - name: http
+              containerPort: 80
+          readinessProbe:
+            httpGet:
+              path: /_status/check
+              port: 80
+            timeoutSeconds: 3
+            periodSeconds: 5
+          resources:
+            limits:
+              memory: "256Mi"
+
+---

--- a/services/certification-ubuntu-com.yaml
+++ b/services/certification-ubuntu-com.yaml
@@ -36,6 +36,12 @@ spec:
             - configMapRef:
                 name: proxy-config
                 optional: true
+          env:
+            - name: SENTRY_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: sentry-dsn
+                  key: certification-ubuntu-com
           readinessProbe:
             httpGet:
               path: /_status/check

--- a/services/certification-ubuntu-com.yaml
+++ b/services/certification-ubuntu-com.yaml
@@ -32,6 +32,10 @@ spec:
           ports:
             - name: http
               containerPort: 80
+          envFrom:
+            - configMapRef:
+                name: proxy-config
+                optional: true
           readinessProbe:
             httpGet:
               path: /_status/check

--- a/services/dqlite-io.yaml
+++ b/services/dqlite-io.yaml
@@ -1,0 +1,55 @@
+---
+
+kind: Service
+apiVersion: v1  # See https://bit.ly/2KdOtrZ
+metadata:
+  name: dqlite-io
+spec:
+  selector:
+    app: dqlite.io
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: http
+
+---
+
+kind: Deployment
+apiVersion: extensions/v1beta1  # See https://bit.ly/2KdOtrZ
+metadata:
+  name: dqlite-io
+spec:
+  replicas: 5
+  template:
+    metadata:
+      labels:
+        app: dqlite.io
+    spec:
+      containers:
+        - name: dqlite-io
+          image: prod-comms.docker-registry.canonical.com/dqlite.io:${TAG_TO_DEPLOY}
+          ports:
+            - name: http
+              containerPort: 80
+          envFrom:
+            - configMapRef:
+                name: proxy-config
+                optional: true
+          env:
+            - name: SENTRY_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: sentry-dsn
+                  key: dqlite-io
+          readinessProbe:
+            httpGet:
+              path: /_status/check
+              port: 80
+            timeoutSeconds: 3
+            periodSeconds: 5
+          resources:
+            limits:
+              memory: "256Mi"
+
+---

--- a/services/etclite-io.yaml
+++ b/services/etclite-io.yaml
@@ -1,0 +1,55 @@
+---
+
+kind: Service
+apiVersion: v1  # See https://bit.ly/2KdOtrZ
+metadata:
+  name: etclite-io
+spec:
+  selector:
+    app: etclite.io
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: http
+
+---
+
+kind: Deployment
+apiVersion: extensions/v1beta1  # See https://bit.ly/2KdOtrZ
+metadata:
+  name: etclite-io
+spec:
+  replicas: 5
+  template:
+    metadata:
+      labels:
+        app: etclite.io
+    spec:
+      containers:
+        - name: etclite-io
+          image: prod-comms.docker-registry.canonical.com/etclite.io:${TAG_TO_DEPLOY}
+          ports:
+            - name: http
+              containerPort: 80
+          envFrom:
+            - configMapRef:
+                name: proxy-config
+                optional: true
+          env:
+            - name: SENTRY_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: sentry-dsn
+                  key: etclite-io
+          readinessProbe:
+            httpGet:
+              path: /_status/check
+              port: 80
+            timeoutSeconds: 3
+            periodSeconds: 5
+          resources:
+            limits:
+              memory: "256Mi"
+
+---

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -32,6 +32,16 @@ spec:
           ports:
             - name: http
               containerPort: 80
+          envFrom:
+            - configMapRef:
+                name: proxy-config
+                optional: true
+          env:
+            - name: SENTRY_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: sentry-dsn
+                  key: {service_name}
           readinessProbe:
             httpGet:
               path: /_status/check


### PR DESCRIPTION
A copy of https://github.com/canonical-web-and-design/deployment-configs/pull/241, but with proxyconfig settings

QA
--

``` bash
./qa-deploy --production certification.ubuntu.com --tag test
./qa-deploy --production dqlite.io --tag test
./qa-deploy --production etclite.io --tag test
watch microk8s.kubectl get all,ingress
```

Once things are "Running" and the IP is assigned to the ingress:

``` bash
curl -I -H 'Host: certification.ubuntu.com' --insecure https://127.0.0.1
curl -I -H 'Host: dqlite.io' --insecure https://127.0.0.1
curl -I -H 'Host: etclite.io' --insecure https://127.0.0.1
```