### PR TITLE
Use 5 replicas for certification

### DIFF
--- a/services/certification-ubuntu-com.yaml
+++ b/services/certification-ubuntu-com.yaml
@@ -20,7 +20,7 @@ apiVersion: extensions/v1beta1  # See https://bit.ly/2KdOtrZ
 metadata:
   name: certification-ubuntu-com
 spec:
-  replicas: 2
+  replicas: 5
   template:
     metadata:
       labels:


### PR DESCRIPTION
I'm not sure why this was set to 2, but it should be 5 like everything else. Especially considering that it gets all its data from an API.