### PR TITLE
A separate service for ubuntu.com/blog

### DIFF
--- a/ingresses/production/ubuntu-com.yaml
+++ b/ingresses/production/ubuntu-com.yaml
@@ -18,6 +18,10 @@ spec:
   - host: ubuntu.com
     http: &ubuntu-com_service
       paths:
+      - path: /blog
+        backend:
+          serviceName: ubuntu-com-blog
+          servicePort: 80
       - path: /
         backend:
           serviceName: ubuntu-com

--- a/ingresses/staging/staging-ubuntu-com.yaml
+++ b/ingresses/staging/staging-ubuntu-com.yaml
@@ -21,11 +21,15 @@ spec:
   - host: staging.ubuntu.com
     http: &ubuntu-com_service
       paths:
+      - path: /blog
+        backend:
+          serviceName: ubuntu-com-blog
+          servicePort: 80
       - path: /
         backend:
           serviceName: ubuntu-com
           servicePort: 80
-  
+
   # Alias domains
   - host: www.staging.ubuntu.com
     http: *ubuntu-com_service

--- a/qa-deploy
+++ b/qa-deploy
@@ -118,13 +118,25 @@ function deploy_service() {
     service="${1}"
     tag="${2}"
 
+    echo "Deploying service ${service}"
     cat "services/${service//./-}.yaml" | sed "s|[:][$][{]TAG_TO_DEPLOY[_aa-zA-Z]*[}]|:${tag}|" | sed 's|replicas: [0-9][0-9]*|replicas: 1|' | microk8s.kubectl apply --filename -
 }
 
 function deploy_ingress() {
     ingress="${1}"
+    tag="${2}"
+
+    ingress_file="ingresses/${ingress//./-}.yaml"
+
+    # Find the services in the ingress
+    services=$(grep 'serviceName' ${ingress_file} | sed -E 's/^ +serviceName: +([^ ]+)$/\1/')
+
+    for service in ${services}; do
+        deploy_service "${service}" "${tag}"
+    done
+
     # Create the ingress domains
-    cat "ingresses/${ingress//./-}.yaml" | sed '/namespace:/d' | microk8s.kubectl apply --filename -
+    cat "${ingress_file}" | sed '/namespace:/d' | microk8s.kubectl apply --filename -
 }
 
 function run() {
@@ -154,6 +166,7 @@ function run() {
 
     # Mandatory arguments
     if [ -z "${production:-}" ]; then invalid "No production domain specified (e.g. 'example.com')"; fi
+    if [ -z "${tag_to_deploy:-}" ]; then tag_to_deploy="latest"; fi
 
     run_microk8s
     # The configuration needs to run before the ingress controller starts
@@ -164,13 +177,9 @@ function run() {
 
     add_docker_credentials_microk8s
 
-    if [ -n "${tag_to_deploy:-}" ]; then
-        deploy_service "${production}" "${tag_to_deploy}"
-    fi
+    deploy_ingress "production/${production}" "${tag_to_deploy}"
 
-    deploy_ingress "production/${production}"
-
-    if [ -n "${staging:-}" ]; then deploy_ingress "staging/${staging}"; fi
+    if [ -n "${staging:-}" ]; then deploy_ingress "staging/${staging}" "${tag_to_deploy}"; fi
 }
 
 run ${@}

--- a/services/ubuntu-com-blog.yaml
+++ b/services/ubuntu-com-blog.yaml
@@ -1,0 +1,60 @@
+---
+
+kind: Service
+apiVersion: v1
+metadata:
+  name: ubuntu-com-blog
+spec:
+  selector:
+    app: ubuntu.com-blog
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: http
+
+---
+
+kind: Deployment
+apiVersion: extensions/v1beta1
+metadata:
+  name: ubuntu-com-blog
+spec:
+  replicas: 5
+  template:
+    metadata:
+      labels:
+        app: ubuntu.com-blog
+    spec:
+      containers:
+        - name: ubuntu-com-blog
+          image: prod-comms.docker-registry.canonical.com/ubuntu.com:${TAG_TO_DEPLOY}
+          ports:
+            - name: http
+              containerPort: 80
+          envFrom:
+            - configMapRef:
+                name: proxy-config
+                optional: true
+          env:
+            - name: SEARCH_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: google-api
+                  key: google-custom-search-key
+            - name: SENTRY_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: sentry-dsn
+                  key: ubuntu-com
+          readinessProbe:
+            httpGet:
+              path: /_status/check
+              port: 80
+            timeoutSeconds: 3
+            periodSeconds: 5
+          resources:
+            limits:
+              memory: "512Mi"
+
+---


### PR DESCRIPTION
This splits out ubuntu.com into 2 services, one to handle requests to `/blog`, and the other to handle the rest of the site.

This will mean that if the whole application for `/blog` goes down for some reason (e.g. 'cos workers are tied up waiting for the API to respond), it shouldn't bring down the rest of the site.

QA
---

``` bash
# Just in case...
snap install microk8s
snap enable microk8s

# Spin up the ingresses
./qa-deploy --production ubuntu.com --staging staging.ubuntu.com
# NB: You'll need to enter credentials to access the image registry

# Watch everything spin up
watch microk8s.kubectl get all,ingress
```

Once all pods are "Running" and all ingresses have an IP address assigned, it's ready for testing.

``` bash
# Get the names of the pods
$ microk8s.kubectl get pods --selector app=ubuntu.com
ubuntu-com-6574b7c875-2whgz
$ microk8s.kubectl get pods --selector app=ubuntu.com-blog
ubuntu-com-blog-6bf9fc6c59-hsgwh
```

Now, in 2 separate terminals, tail the logs for each:

``` bash
microk8s.kubectl logs --follow ubuntu-com-6574b7c875-2whgz
```

and

``` bash
microk8s.kubectl logs --follow ubuntu-com-blog-6bf9fc6c59-hsgwh
```

Now try hitting the services with `curl`, and check the logs are updating on the correct pod:

``` bash
curl -I -H 'Host: ubuntu.com' http://localhost/
curl -I -H 'Host: ubuntu.com' http://localhost/blog
curl -I -H 'Host: staging.ubuntu.com' http://localhost/
curl -I -H 'Host: staging.ubuntu.com' http://localhost/blog
```

Now we can try updating our `/etc/hosts`:

``` bash
echo "127.0.0.1 ubuntu.com staging.ubuntu.com" | sudo tee -a /etc/hosts
```

Now, **in a private window**, go to http://ubuntu.com (*note the `http`*) and https://staging.ubuntu.com (*note the `https`*). Browse around, check it works, and visit `/blog` and check that works.

Now remove the entry in `/etc/hosts`:

``` bash
sudo sed -i '/127.0.0.1 ubuntu.com/d' /etc/hosts
```