### PR TITLE
Simplify snapcraft.io config

### DIFF
--- a/services/snapcraft-io.yaml
+++ b/services/snapcraft-io.yaml
@@ -19,15 +19,12 @@ kind: Deployment
 apiVersion: extensions/v1beta1
 metadata:
   name: snapcraft-io
-  labels:
-    useProxy: "true"
 spec:
   replicas: 5
   template:
     metadata:
       labels:
         app: snapcraft.io
-        useProxy: "true"
     spec:
       containers:
         - name: snapcraft-io
@@ -50,47 +47,22 @@ spec:
                 configMapKeyRef:
                   name: environment
                   key: environment
-            - name: BSI_URL
-              valueFrom:
-                configMapKeyRef:
-                  name: snapcraft-io
-                  optional: true
-                  key: bsi_url
-            - name: BLOG_ENABLED
-              valueFrom:
-                configMapKeyRef:
-                  name: snapcraft-io
-                  optional: True
-                  key: blog_enabled
+
+            # Secrets
             - name: SECRET_KEY
               valueFrom:
                 secretKeyRef:
-                  name: snapcraft-io-config
-                  key: secret_key
-            - name: WTF_CSRF_SECRET_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: snapcraft-io-config
-                  key: csrf_secret_key
-            - name: SENTRY_PUBLIC_DSN
-              valueFrom:
-                secretKeyRef:
-                  name: snapcraft-io-config
-                  key: sentry_public_dsn
-            - name: MARKETO_URL
-              valueFrom:
-                configMapKeyRef:
                   name: snapcraft-io
-                  key: marketo_url
+                  key: secret_key
             - name: MARKETO_CLIENT_ID
               valueFrom:
                 secretKeyRef:
-                  name: snapcraft-io-config
+                  name: snapcraft-io
                   key: marketo_client_id
             - name: MARKETO_CLIENT_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: snapcraft-io-config
+                  name: snapcraft-io
                   key: marketo_client_secret
             - name: SEARCH_API_KEY
               valueFrom:

--- a/services/staging-api-snapcraft-io.yaml
+++ b/services/staging-api-snapcraft-io.yaml
@@ -42,43 +42,35 @@ spec:
             - configMapRef:
                 name: staging-api-snapcraft-io
           env:
+            - name: SENTRY_DSN
+              value: https://1e82fd54e08142c9978f623cb746b965@sentry.is.canonical.com//3
             - name: ENVIRONMENT
               valueFrom:
                 configMapKeyRef:
                   name: environment
                   key: environment
-            - name: BSI_URL
-              valueFrom:
-                configMapKeyRef:
-                  name: snapcraft-io
-                  optional: true
-                  key: bsi_url
-            - name: BLOG_ENABLED
-              valueFrom:
-                configMapKeyRef:
-                  name: snapcraft-io
-                  optional: True
-                  key: blog_enabled
+
+            # Secrets
             - name: SECRET_KEY
               valueFrom:
                 secretKeyRef:
-                  name: snapcraft-io-config
+                  name: snapcraft-io
                   key: secret_key
-            - name: WTF_CSRF_SECRET_KEY
+            - name: MARKETO_CLIENT_ID
               valueFrom:
                 secretKeyRef:
-                  name: snapcraft-io-config
-                  key: csrf_secret_key
-            - name: SENTRY_DSN
+                  name: snapcraft-io
+                  key: marketo_client_id
+            - name: MARKETO_CLIENT_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: snapcraft-io-config
-                  key: sentry_dsn
-            - name: SENTRY_PUBLIC_DSN
+                  name: snapcraft-io
+                  key: marketo_client_secret
+            - name: SEARCH_API_KEY
               valueFrom:
                 secretKeyRef:
-                  name: snapcraft-io-config
-                  key: sentry_public_dsn
+                  name: google-api
+                  key: google-custom-search-key
           readinessProbe:
             httpGet:
               path: /_status/check


### PR DESCRIPTION
This will require some other changes first.

Firstly, https://github.com/canonical-web-and-design/snapcraft.io/pull/2266 
needs to be merged and released so we don't any longer need
SENTRY_PUBLIC_DSN.

Secondly, we need to consolidate all relevant values in the `snapcraft-io`
secret.

QA
--

`./qa-deploy --production snapcraft.io`