### PR TITLE
Double memory for snapcraft-io containers

### DIFF
--- a/services/snapcraft-io.yaml
+++ b/services/snapcraft-io.yaml
@@ -105,6 +105,6 @@ spec:
             periodSeconds: 5
           resources:
             limits:
-              memory: "512Mi"
+              memory: "1024Mi"
 
 ---


### PR DESCRIPTION
Fixes https://github.com/canonical-web-and-design/base-squad/issues/729