### PR TITLE
Try pre-connecting to useful domains

### DIFF
--- a/ingresses/production/ubuntu-com.yaml
+++ b/ingresses/production/ubuntu-com.yaml
@@ -12,6 +12,7 @@ metadata:
       if ($host != 'ubuntu.com' ) {
         rewrite ^ https://ubuntu.com$request_uri? permanent;
       }
+      more_set_headers "Link: <https://assets.ubuntu.com>; rel=preconnect; crossorigin, <https://www.google-analytics.com>; rel=preconnect; crossorigin, <https://www.gstatic.com>; rel=preconnect; crossorigin, <https://res.cloudinary.com>; rel=preconnect; crossorigin";
 
 spec:
   rules:

--- a/ingresses/staging/staging-ubuntu-com.yaml
+++ b/ingresses/staging/staging-ubuntu-com.yaml
@@ -8,10 +8,11 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/configuration-snippet: |
-      more_set_headers "X-Robots-Tag: noindex";
       if ($host != 'staging.ubuntu.com' ) {
         rewrite ^ https://staging.ubuntu.com$request_uri? permanent;
       }
+      more_set_headers "X-Robots-Tag: noindex";
+      more_set_headers "Link: <https://assets.ubuntu.com>; rel=preconnect; crossorigin, <https://www.google-analytics.com>; rel=preconnect; crossorigin, <https://www.gstatic.com>; rel=preconnect; crossorigin, <https://res.cloudinary.com>; rel=preconnect; crossorigin";
 spec:
   tls:
   - secretName: staging-ubuntu-com-tls


### PR DESCRIPTION
Add headers to prefetch the domains defined in [ubuntu.com's source](view-source:https://ubuntu.com/).

QA
--

```
./qa-deploy --production ubuntu.com
watch microk8s.kubectl get all,ingress
```

Once things are ready:

```
curl -I -H 'Host: ubuntu.com' http://127.0.0.1
```

Check you can see the `Link:` headers.