### PR TITLE
Enable TLSv1.3

### DIFF
--- a/configmaps/nginx-configuration.yaml
+++ b/configmaps/nginx-configuration.yaml
@@ -11,6 +11,7 @@ data:
   proxy-buffer-size: "8k"
   proxy-buffers: "4 8k"
   enable-brotli: "true"
+  ssl-protocols: "TLSv1.3 TLSv1.2"
 kind: ConfigMap
 metadata:
   name: nginx-configuration


### PR DESCRIPTION
TLSv1.3 [comes with significant performance benefits](https://www.cloudflare.com/learning-resources/tls-1-3/) through collapsing round-trips.

It's not enabled by default in the nginx ingress controller but is [trivial to enable](https://github.com/kubernetes/ingress-nginx/releases/tag/nginx-0.21.0).

I'm not sure why it's not enabled by default, I [asked](https://github.com/kubernetes/ingress-nginx/issues/2384#issuecomment-538321426), maybe I'll get a response.

QA
--

`./qa-deploy --production snapcraft.io`, make sure the site runs fine. Try adding `127.0.0.1 snapcraft.io` to your `/etc/hosts` and loading `https://snapcraft.io` in a private window. Check the site works.