### PR TITLE
Re-enable HTTP/2

### DIFF
--- a/configmaps/nginx-configuration.yaml
+++ b/configmaps/nginx-configuration.yaml
@@ -10,7 +10,6 @@ data:
   proxy-body-size: "0"
   proxy-buffer-size: "8k"
   proxy-buffers: "4 8k"
-  use-http2: "false"
   enable-brotli: "true"
 kind: ConfigMap
 metadata:


### PR DESCRIPTION
The have to wait for Nginx v1.16.1, which fixes [the DoS vulnerabilities](https://www.nginx.com/blog/nginx-updates-mitigate-august-2019-http-2-vulnerabilities/).

Nginx v1.16.1 should be live once [RT #121713](https://portal.admin.canonical.com/C121713) is resolved.

QA
--

`./qa-deploy --production snapcraft.io`
`curl -I --insecure -H 'Host: snapcraft.io' https://127.0.0.1`

Check it's `HTTP/2`.