### PR TITLE
Enable brotli compression

### DIFF
--- a/configmaps/nginx-configuration.yaml
+++ b/configmaps/nginx-configuration.yaml
@@ -11,6 +11,7 @@ data:
   proxy-buffer-size: "8k"
   proxy-buffers: "4 8k"
   use-http2: "false"
+  enable-brotli: "true"
 kind: ConfigMap
 metadata:
   name: nginx-configuration

--- a/qa-deploy
+++ b/qa-deploy
@@ -28,8 +28,8 @@ function invalid() {
 
 function add_secrets() {
     # Fake snapcraft config
-    if microk8s.kubectl get secret snapcraft-io-config &> /dev/null; then microk8s.kubectl delete secret snapcraft-io-config; fi
-    microk8s.kubectl create secret generic snapcraft-io-config \
+    if microk8s.kubectl get secret snapcraft-io &> /dev/null; then microk8s.kubectl delete secret snapcraft-io; fi
+    microk8s.kubectl create secret generic snapcraft-io \
         --from-literal=secret_key=admin \
         --from-literal=csrf_secret_key=admin \
         --from-literal='sentry_dsn=' \
@@ -71,8 +71,9 @@ function add_docker_credentials_microk8s() {
 }
 
 function apply_configuration() {
-    microk8s.kubectl apply -f config.qa.yaml
-
+    if ! microk8s.kubectl get configmap environment &> /dev/null; then
+        microk8s.kubectl create configmap environment --from-literal environment=qa;
+    fi
     # On the version of the ingress controller we have we need to change the
     # name to be able to apply the configuration. By default the nginx ingress
     # controller is searching for a config-map called: nginx-load-balancer-microk8s-conf


### PR DESCRIPTION
[Enable brotli](https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/configmap.md#enable-brotli). Note, it will only work for HTTPS sites. I don't know what it will do for ubuntu.com, where HTTPS is terminated outside k8s. Hopefully it will be able to respect an `X-Forwarded-Proto` header, we'll see.

QA
--

`./qa-deploy --production snapcraft.io`

```
$ curl -sI --insecure -H 'Accept-Encoding: br,gzip,deflate' -H 'Host: snapcraft.io' https://127.0.0.1/static/js/dist/global-nav.js | grep Encoding
Vary: Accept-Encoding
Content-Encoding: br
```