### PR TITLE
Remove crossorigin for preconnects

### DIFF
--- a/ingresses/production/ubuntu-com.yaml
+++ b/ingresses/production/ubuntu-com.yaml
@@ -12,7 +12,7 @@ metadata:
       if ($host != 'ubuntu.com' ) {
         rewrite ^ https://ubuntu.com$request_uri? permanent;
       }
-      more_set_headers "Link: <https://assets.ubuntu.com>; rel=preconnect; crossorigin, <https://www.google-analytics.com>; rel=preconnect; crossorigin, <https://www.gstatic.com>; rel=preconnect; crossorigin, <https://res.cloudinary.com>; rel=preconnect; crossorigin";
+      more_set_headers "Link: <https://assets.ubuntu.com>; rel=preconnect; crossorigin, <https://assets.ubuntu.com>; rel=preconnect, <https://www.google-analytics.com>; rel=preconnect, <https://www.gstatic.com>; rel=preconnect, <https://res.cloudinary.com>; rel=preconnect";
 
 spec:
   rules:

--- a/ingresses/staging/staging-ubuntu-com.yaml
+++ b/ingresses/staging/staging-ubuntu-com.yaml
@@ -12,7 +12,7 @@ metadata:
         rewrite ^ https://staging.ubuntu.com$request_uri? permanent;
       }
       more_set_headers "X-Robots-Tag: noindex";
-      more_set_headers "Link: <https://assets.ubuntu.com>; rel=preconnect; crossorigin, <https://www.google-analytics.com>; rel=preconnect; crossorigin, <https://www.gstatic.com>; rel=preconnect; crossorigin, <https://res.cloudinary.com>; rel=preconnect; crossorigin";
+      more_set_headers "Link: <https://assets.ubuntu.com>; rel=preconnect; crossorigin, <https://assets.ubuntu.com>; rel=preconnect, <https://www.google-analytics.com>; rel=preconnect, <https://www.gstatic.com>; rel=preconnect, <https://res.cloudinary.com>; rel=preconnect";
 spec:
   tls:
   - secretName: staging-ubuntu-com-tls


### PR DESCRIPTION
It seems we shouldn't use `crossorigin` for anything other than fonts.