### PR TITLE
Add configs for manager.assets.ubuntu.com

### DIFF
--- a/ingresses/production/manager-assets-ubuntu-com.yaml
+++ b/ingresses/production/manager-assets-ubuntu-com.yaml
@@ -1,0 +1,27 @@
+---
+
+kind: Ingress
+apiVersion: extensions/v1beta1  # See https://bit.ly/2KdOtrZ
+metadata:
+  name: manager-assets-ubuntu-com
+  namespace: production
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      more_set_headers "X-Robots-Tag: noindex";
+spec:
+  tls:
+  - secretName: manager-assets-ubuntu-com-tls
+    hosts:
+    - manager.assets.ubuntu.com
+  rules:
+  - host: manager.assets.ubuntu.com
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: manager-assets-ubuntu-com
+          servicePort: 80
+
+---

--- a/ingresses/staging/manager-staging-assets-ubuntu.yaml
+++ b/ingresses/staging/manager-staging-assets-ubuntu.yaml
@@ -1,0 +1,27 @@
+---
+
+kind: Ingress
+apiVersion: extensions/v1beta1  # See https://bit.ly/2KdOtrZ
+metadata:
+  name: manager-staging-assets-ubuntu
+  namespace: staging
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      more_set_headers "X-Robots-Tag: noindex";
+spec:
+  tls:
+  - secretName: manager-staging-assets-ubuntu-tls
+    hosts:
+    - manager.staging.assets.ubuntu
+  rules:
+  - host: manager.staging.assets.ubuntu
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: manager-assets-ubuntu-com
+          servicePort: 80
+
+---

--- a/services/manager-assets-ubuntu-com.yaml
+++ b/services/manager-assets-ubuntu-com.yaml
@@ -1,0 +1,65 @@
+---
+
+kind: Service
+apiVersion: v1  # See https://bit.ly/2KdOtrZ
+metadata:
+  name: manager-assets-ubuntu-com
+spec:
+  selector:
+    app: manager.assets.ubuntu.com
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: http
+
+---
+
+kind: Deployment
+apiVersion: extensions/v1beta1  # See https://bit.ly/2KdOtrZ
+metadata:
+  name: manager-assets-ubuntu-com
+spec:
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        app: manager.assets.ubuntu.com
+    spec:
+      containers:
+        - name: manager-assets-ubuntu-com
+          image: prod-comms.docker-registry.canonical.com/manager.assets.ubuntu.com:${TAG_TO_DEPLOY}
+          ports:
+            - name: http
+              containerPort: 80
+          envFrom:
+            - configMapRef:
+                name: envvars
+                optional: true
+            - configMapRef:
+                name: proxy-config
+                optional: true
+          env:
+            - name: ASSET_SERVER_URL
+              value: https://assets.ubuntu.com/v1/
+            - name: ASSET_SERVER_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: manager-assets-ubuntu-com
+                  key: asset_server_token
+            - name: SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: manager-assets-ubuntu-com
+                  key: secret_key
+          readinessProbe:
+            httpGet:
+              path: /_status/check
+              port: 80
+            timeoutSeconds: 3
+            periodSeconds: 5
+          resources:
+            limits:
+              memory: "256Mi"
+
+---


### PR DESCRIPTION
Add k8s configurations for manager.assets.ubuntu.com

## QA
- `microk8s.kubectl create secret generic manager-assets-ubuntu-com --from-literal=asset_server_token=<token> --from-literal=secret_key=notsosecret`
- `./qa-deploy --production manager.assets.ubuntu.com --tag test`
- `echo "127.0.0.1 manager.assets.ubuntu.com" | sudo tee -a /etc/hosts`
- Check `http` redirects to `https`
- Verify the site works
- `sudo sed -i '/manager.assets.ubuntu.com/d' /etc/hosts`