### PR TITLE
Remove unused domains

### DIFF
--- a/ingresses/production/developer-ubuntu-com.yaml
+++ b/ingresses/production/developer-ubuntu-com.yaml
@@ -25,10 +25,4 @@ spec:
           serviceName: developer-ubuntu-com
           servicePort: 80
 
-  # Alias domains
-  - host: developers.ubuntu.com
-    http: *developer-ubuntu-com_service
-  - host: dev.ubuntu.com
-    http: *developer-ubuntu-com_service
-
 ---


### PR DESCRIPTION
As we have agreed, this will remove:
- developers.ubuntu.com
- dev.ubuntu.com

From the ingress file `ingresses/production/developer-ubuntu-com.yaml`