### PR TITLE
Added missing preconnect header for docs.ubuntu.com

### DIFF
--- a/ingresses/production/docs-ubuntu-com.yaml
+++ b/ingresses/production/docs-ubuntu-com.yaml
@@ -7,6 +7,8 @@ metadata:
   namespace: production
   annotations:
     kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      more_set_headers "Link: <https://assets.ubuntu.com>; rel=preconnect; crossorigin, <https://assets.ubuntu.com>; rel=preconnect";
 spec:
   tls:
   - secretName: docs-ubuntu-com-tls


### PR DESCRIPTION
It looks like this project was skipped when adding the header for our projects: https://github.com/canonical-web-and-design/deployment-configs/pull/259

The issue is in the production ingress file, the staging ingress file is correct.