### PR TITLE
Fix typo for docs.staging.maas.io

### DIFF
--- a/ingresses/staging/staging-maas-io.yaml
+++ b/ingresses/staging/staging-maas-io.yaml
@@ -20,7 +20,7 @@ spec:
     - staging.maas.io
   - secretName: docs-staging-maas-io-tls
     hosts:
-    - docs-staging.maas.io
+    - docs.staging.maas.io
   rules:
   - host: staging.maas.io
     http: &maas-io_service


### PR DESCRIPTION
The TLS host for docs.staging.maas.io is wrong, and as you can see a few lines up in the Nginx config the domain should be docs.staging.maas.io not docs-staging.maas.io