### PR TITLE
Remove unused host in old-docs.maas.io

### DIFF
--- a/ingresses/production/old-docs-maas-io.yaml
+++ b/ingresses/production/old-docs-maas-io.yaml
@@ -18,9 +18,6 @@ spec:
   - secretName: old-docs-maas-io-tls
     hosts:
     - old-docs.maas.io
-  - secretName: docs-maas-io-tls
-    hosts:
-    - docs.maas.io
   rules:
   - host: old-docs.maas.io
     http: &old-docs-maas-io_service

--- a/ingresses/staging/old-docs-staging-maas-io.yaml
+++ b/ingresses/staging/old-docs-staging-maas-io.yaml
@@ -18,9 +18,6 @@ spec:
   - secretName: old-docs-staging-maas-io-tls
     hosts:
     - old-docs.staging.maas.io
-  - secretName: docs-staging-maas-io-tls
-    hosts:
-    - docs.staging.maas.io
   rules:
   - host: old-docs.staging.maas.io
     http: &old-docs-maas-io_service


### PR DESCRIPTION
The ingress file for old-docs.maas.io, contain the TLS secretName for docs.maas.io when it is already defined in maas.io:

`ingresses/production/old-docs-maas-io.yaml`
```
spec:
  tls:
  - secretName: docs-maas-io-tls
    hosts:
    - docs.maas.io
```

It also does not contain the rule so we should eliminate it and only have it defined in maas.io:
`ingresses/production/maas-io.yaml`
```
spec:
  tls:
  - secretName: docs-maas-io-tls
    hosts:
    - docs.maas.io
[...]
  rules:
  - host: docs.maas.io
    http: *maas-io_service
```

The same applies for staging.