### PR TITLE
Add configs for charmed-osm.com

### DIFF
--- a/ingresses/production/charmed-osm-com.yaml
+++ b/ingresses/production/charmed-osm-com.yaml
@@ -1,0 +1,34 @@
+---
+
+kind: Ingress
+apiVersion: extensions/v1beta1  # See https://bit.ly/2KdOtrZ
+metadata:
+  name: charmed-osm-com
+  namespace: production
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      if ($host != 'charmed-osm.com' ) {
+        rewrite ^ https://charmed-osm.com$request_uri? permanent;
+      }
+      more_set_headers "Link: <https://assets.ubuntu.com>; rel=preconnect; crossorigin, <https://assets.ubuntu.com>; rel=preconnect";
+spec:
+  tls:
+  - secretName: charmed-osm-com-tls
+    hosts:
+    - charmed-osm.com
+    - www.charmed-osm.com
+  rules:
+  - host: charmed-osm.com
+    http: &charmed-osm-com_service
+      paths:
+      - path: /
+        backend:
+          serviceName: charmed-osm-com
+          servicePort: 80
+
+  # Alias domains
+  - host: www.charmed-osm.com
+    http: *charmed-osm-com_service
+
+---

--- a/ingresses/staging/staging-charmed-osm-com.yaml
+++ b/ingresses/staging/staging-charmed-osm-com.yaml
@@ -1,0 +1,27 @@
+---
+
+kind: Ingress
+apiVersion: extensions/v1beta1  # See https://bit.ly/2KdOtrZ
+metadata:
+  name: staging-charmed-osm-com
+  namespace: staging
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      more_set_headers "X-Robots-Tag: noindex";
+      more_set_headers "Link: <https://assets.ubuntu.com>; rel=preconnect; crossorigin, <https://assets.ubuntu.com>; rel=preconnect";
+spec:
+  tls:
+  - secretName: staging-charmed-osm-com-tls
+    hosts:
+    - staging.charmed-osm.com
+  rules:
+  - host: staging.charmed-osm.com
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: charmed-osm-com
+          servicePort: 80
+
+---

--- a/services/charmed-osm-com.yaml
+++ b/services/charmed-osm-com.yaml
@@ -1,0 +1,52 @@
+---
+
+kind: Service
+apiVersion: v1  # See https://bit.ly/2KdOtrZ
+metadata:
+  name: charmed-osm-com
+spec:
+  selector:
+    app: charmed-osm.com
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: http
+
+---
+
+kind: Deployment
+apiVersion: extensions/v1beta1  # See https://bit.ly/2KdOtrZ
+metadata:
+  name: charmed-osm-com
+spec:
+  replicas: 5
+  template:
+    metadata:
+      labels:
+        app: charmed-osm.com
+    spec:
+      containers:
+        - name: charmed-osm-com
+          image: prod-comms.docker-registry.canonical.com/charmed-osm.com:${TAG_TO_DEPLOY}
+          ports:
+            - name: http
+              containerPort: 80
+          envFrom:
+            - configMapRef:
+                name: envvars
+                optional: true
+            - configMapRef:
+                name: proxy-config
+                optional: true
+          readinessProbe:
+            httpGet:
+              path: /_status/check
+              port: 80
+            timeoutSeconds: 3
+            periodSeconds: 5
+          resources:
+            limits:
+              memory: "256Mi"
+
+---


### PR DESCRIPTION
QA
--

``` bash
# Optional - just to be on the safe side
sudo snap install microk8s --channel=1.15/stable --classic && microk8s.reset && snap disable microk8s && snap enable microk8s

# Now deploy things
./qa-deploy --production charmed-osm.com --staging staging.charmed-osm-com  --tag test
microk8s.kubectl get all,ingress
```

Once the pods are all "Running" and the ingresses have the `127.0.0.1` IP address assigned:

``` bash
echo "127.0.0.1 charmed-osm.com" | sudo tee -a /etc/hosts
```

Now go to http://charmed-osm.com/ and check the site is running.

Then remove the hosts again:

``` bash
sudo sed -i '/charmed-osm.com/d' /etc/hosts
```