### PR TITLE
Typo on ingress file for staging.snapcraft.io

### DIFF
--- a/ingresses/staging/staging-snapcraft-io.yaml
+++ b/ingresses/staging/staging-snapcraft-io.yaml
@@ -20,7 +20,7 @@ spec:
     - staging.snapcraft.io
   - secretName: docs-staging-snapcraft-io-tls
     hosts:
-    - docs-staging.snapcraft.io
+    - docs.staging.snapcraft.io
   rules:
   - host: staging.snapcraft.io
     http: &snapcraft-io_service


### PR DESCRIPTION
There is a typo in this line:
https://github.com/canonical-web-and-design/deployment-configs/blob/15e7d920ac08275add2a123012c919aed21a291b/ingresses/staging/staging-snapcraft-io.yaml#L23

As you can see in the rest of the file we are using "docs.staging.snapcraft.io" not "docs-staging.snapcraft.io"
https://github.com/canonical-web-and-design/deployment-configs/blob/15e7d920ac08275add2a123012c919aed21a291b/ingresses/staging/staging-snapcraft-io.yaml#L11

https://github.com/canonical-web-and-design/deployment-configs/blob/15e7d920ac08275add2a123012c919aed21a291b/ingresses/staging/staging-snapcraft-io.yaml#L33