### PR TITLE
Increase memory for jaas.ai

### DIFF
--- a/services/jaas-ai.yaml
+++ b/services/jaas-ai.yaml
@@ -52,6 +52,6 @@ spec:
             periodSeconds: 5
           resources:
             limits:
-              memory: "256Mi"
+              memory: "512Mi"
 
 ---


### PR DESCRIPTION
Give jaas.ai containers more memory, since they seem to be running out of it a lot of times.