### PR TITLE
Allow-origin * for /blog/latest-news

### DIFF
--- a/sites/ubuntu.com.yaml
+++ b/sites/ubuntu.com.yaml
@@ -48,6 +48,9 @@ production:
     if ($host != 'ubuntu.com' ) {
       rewrite ^ https://ubuntu.com$request_uri? permanent;
     }
+    if ($request_uri = '/blog/latest-news') {
+      add_header 'Access-Control-Allow-Origin' '*';
+    }
     more_set_headers "Link: <https://assets.ubuntu.com>; rel=preconnect; crossorigin, <https://assets.ubuntu.com>; rel=preconnect, <https://res.cloudinary.com>; rel=preconnect";
 
   nginxSSLRedirect: False
@@ -73,6 +76,9 @@ staging:
   nginxConfigurationSnippet: |
     if ($host != 'staging.ubuntu.com' ) {
       rewrite ^ https://staging.ubuntu.com$request_uri? permanent;
+    }
+    if ($request_uri = '/blog/latest-news') {
+      add_header 'Access-Control-Allow-Origin' '*';
     }
     more_set_headers "X-Robots-Tag: noindex";
     more_set_headers "Link: <https://assets.ubuntu.com>; rel=preconnect; crossorigin, <https://assets.ubuntu.com>; rel=preconnect, <https://res.cloudinary.com>; rel=preconnect";

--- a/templates/site.yaml
+++ b/templates/site.yaml
@@ -15,7 +15,7 @@
 {% include 'deployment.yaml' %}
 
 {% if "routes" in data %}
-  {% for route in data.routes %}
+  {%- for route in data.routes %}
     {%- with
         name=get_site_name() ~ route.path|replace("/", "-"),
         domain=domain ~ route.path|replace("/", "-"),


### PR DESCRIPTION
This is so client-side news feeds can be added to other sites,
like maas.io.

This supports https://github.com/canonical-web-and-design/maas.io/issues/400.

QA
--

``` bash
snap install microk8s --channel 1.15/stable
# or
snap enable microk8s

./qa-deploy production sites/ubuntu.com.yaml  # Deploy ubuntu.com

watch microk8s.kubectl get all,ingress
```

Once that's all up and running (Pods are "Running", IPs assigned), then:

``` bash
$ curl -H 'Host: ubuntu.com' 127.0.0.1
HTTP/1.1 200 OK
...
# no access-control-allow-origin header

$ curl -H 'Host: ubuntu.com' 127.0.0.1/blog
HTTP/1.1 200 OK
...
# no access-control-allow-origin header

$ curl -H 'Host: ubuntu.com' 127.0.0.1/blog/latest-news
HTTP/1.1 200 OK
...
Access-Control-Allow-Origin: *
```

^ Check we see `Access-Control-Allow-Origin: *` only on `/blog/latest-news`.