### PR TITLE
Support query strings on /blog/latest-news

### DIFF
--- a/sites/ubuntu.com.yaml
+++ b/sites/ubuntu.com.yaml
@@ -48,7 +48,7 @@ production:
     if ($host != 'ubuntu.com' ) {
       rewrite ^ https://ubuntu.com$request_uri? permanent;
     }
-    if ($request_uri = '/blog/latest-news') {
+    if ($uri = '/blog/latest-news') {
       add_header 'Access-Control-Allow-Origin' '*';
     }
     more_set_headers "Link: <https://assets.ubuntu.com>; rel=preconnect; crossorigin, <https://assets.ubuntu.com>; rel=preconnect, <https://res.cloudinary.com>; rel=preconnect";


### PR DESCRIPTION
Serve the access-control-allow-origin header even if there's a query
string.

QA
--

``` bash
./qa-deploy production sites/ubuntu.com.yaml
watch microk8s.kubectl get all,ingress
```

^ once everything is `Running` and the ingress has `ADDRESS 127.0.0.1` assigned, then run:

``` bash
$ curl -I -H 'Host: ubuntu.com' 'http://127.0.0.1/blog/latest-news?tag-id=1304'
HTTP/1.1 200 OK
...
Access-Control-Allow-Origin: *          
```

^ Check you see the correct header.