### PR TITLE
Remove dashboard routes from jaas.ai

### DIFF
--- a/sites/jaas.ai.yaml
+++ b/sites/jaas.ai.yaml
@@ -30,13 +30,6 @@ production:
     }
     more_set_headers "Link: <https://assets.ubuntu.com>; rel=preconnect; crossorigin, <https://assets.ubuntu.com>; rel=preconnect";
 
-  routes:
-    - paths: [/models, /static, /controllers]
-      name: jaas-ai-dashboard
-      app_name: jaas.ai-dashboard
-      image: prod-comms.docker-registry.canonical.com/jaas.ai-dashboard
-      replicas: 5
-
 # Overrides for staging
 staging:
   replicas: 3
@@ -46,10 +39,3 @@ staging:
       rewrite ^ https://staging.jaas.ai/docs$request_uri? permanent;
     }
     more_set_headers "Link: <https://assets.ubuntu.com>; rel=preconnect; crossorigin, <https://assets.ubuntu.com>; rel=preconnect";
-
-  routes:
-    - paths: [/models, /static, /controllers]
-      name: jaas-ai-dashboard
-      app_name: jaas.ai-dashboard
-      image: prod-comms.docker-registry.canonical.com/jaas.ai-dashboard
-      replicas: 3


### PR DESCRIPTION
We've decided to put the dashboard directly in the jaas.ai dockerfile instead:
https://github.com/canonical-web-and-design/jaas.ai/pull/498

QA
--

``` bash
./qa-deploy production sites/jaas.ai.yaml
watch microk8s.kubectl get all,ingress
```

And add `jaas.ai` to `/etc/hosts`:

``` bash
echo "127.0.0.1 jaas.ai" | sudo tee -a /etc/hosts
```

^ once everything is `Running` and the ingress has `ADDRESS 127.0.0.1` assigned, go to https://jaas.ai/, check it works fine.

Now clean up `/etc/hosts`:

``` bash
sudo sed -i '/ jaas.ai/d' /etc/hosts
```