### PR TITLE
Add GitHub and Launchpad secrets for Snapcraft

### DIFF
--- a/sites/snapcraft.io.yaml
+++ b/sites/snapcraft.io.yaml
@@ -31,6 +31,31 @@ env:
       key: google-custom-search-key
       name: google-api
 
+  - name: GITHUB_CLIENT_ID
+    secretKeyRef:
+      key: github-client-id
+      name: snapcraft-io
+
+  - name: GITHUB_CLIENT_SECRET
+    secretKeyRef:
+      key: github-client-secret
+      name: snapcraft-io
+
+  - name: LP_API_USERNAME
+    secretKeyRef:
+      key: lp-api-username
+      name: snapcraft-io
+
+  - name: LP_API_TOKEN
+    secretKeyRef:
+      key: lp-api-token
+      name: snapcraft-io
+
+  - name: LP_API_TOKEN_SECRET
+    secretKeyRef:
+      key: lp-api-token-secret
+      name: snapcraft-io
+
 memoryLimit: 1Gi
 
 extraHosts:


### PR DESCRIPTION
### Done
- Added some secrets for Snapcraft needed for the GitHub API and Launchpad API

### QA

```bash
/qa-deploy staging sites/snapcraft.io.yaml

curl -I -H 'Host: snapcraft.io' http://127.0.0.1/
```