### PR TITLE
Add redirect from download.ubuntu.com

### DIFF
--- a/sites/ubuntu.com.yaml
+++ b/sites/ubuntu.com.yaml
@@ -20,6 +20,7 @@ extraHosts:
   - domain: insights.ubuntu.com
   - domain: ubunut.com
   - domain: ubuntulinux.org
+  - domain: download.ubuntu.com
 
 # Overrides for production
 production:
@@ -57,6 +58,9 @@ production:
         value: https://0293bb7fc3104e56bafd2422e155790c@sentry.is.canonical.com//13
 
   nginxConfigurationSnippet: |
+    if ($host = 'download.ubuntu.com' ) {
+      rewrite ^ https://ubuntu.com/download$request_uri? permanent;
+    }
     if ($host = 'tutorials.ubuntu.com' ) {
       rewrite ^ https://ubuntu.com/tutorials$request_uri? permanent;
     }


### PR DESCRIPTION
# Summary 

Redirect download.ubuntu.com to ubuntu.com/download

Fixes https://github.com/canonical-web-and-design/web-squad/issues/2376