### PR TITLE
Added SEARCH_API_KEY for vanillaframework

### DIFF
--- a/sites/vanillaframework.io.yaml
+++ b/sites/vanillaframework.io.yaml
@@ -4,6 +4,12 @@ image: prod-comms.docker-registry.canonical.com/vanillaframework.io
 
 useProxy: false
 
+env:
+  - name: SEARCH_API_KEY
+    secretKeyRef:
+      key: google-custom-search-key
+      name: google-api
+
 extraHosts:
   - domain: docs.vanillaframework.io
 


### PR DESCRIPTION
There is a missing secret from the docs deployment that we now need in vanillaframework.io.