### PR TITLE
Config for feedinghopeandheroes.org

### DIFF
--- a/sites/feedinghopeandheroes.org.yaml
+++ b/sites/feedinghopeandheroes.org.yaml
@@ -1,0 +1,11 @@
+domain: feedinghopeandheroes.org
+
+image: prod-comms.docker-registry.canonical.com/feedinghopeandheroes.org
+
+# Overrides for production
+production:
+  replicas: 5
+
+# Overrides for staging
+staging:
+  replicas: 3


### PR DESCRIPTION
QA
--

```
snap install --channel=1.15/stable microk8s  # Install microk8s if needed
echo "127.0.0.1 feedinghopeandheroes.org" | sudo tee -a /etc/hosts  # Set up local DNS
./qa-deploy production sites/feedinghopeandheroes.org.yaml  # Deploy site
watch 'microk8s.kubectl get pod'  # Watch for updates
```

^ Once the "feedinghopeandheroes" pod is "Running", try visiting https://feedinghopeandheroes.org in your browser. You'll have to accept the invalid cert, but then you should see "THIS IS A HOMEPAGE"