### PR TITLE
Poller script

### DIFF
--- a/cronjobs/snapcraft-poller-script.yaml
+++ b/cronjobs/snapcraft-poller-script.yaml
@@ -1,0 +1,22 @@
+name: snapcraft-poller-script
+schedule: "0 5 * * *"
+image: prod-comms.docker-registry.canonical.com/snapcraft-poller-script
+
+env:
+  - name: SENTRY_DSN
+    value: https://d920c219edb44a349c683174e37d26c7@sentry.is.canonical.com//25
+
+  - name: LP_API_TOKEN
+    secretKeyRef:
+      key: lp-api-token
+      name: snapcraft-io
+
+  - name: LP_API_TOKEN_SECRET
+    secretKeyRef:
+      key: lp-api-token-secret
+      name: snapcraft-io
+
+  - name: GITHUB_SNAPCRAFT_POLLER_TOKENS
+    secretKeyRef:
+      key: github-snapcraft-poller-tokens
+      name: snapcraft-io

--- a/templates/cronjob.yaml
+++ b/templates/cronjob.yaml
@@ -12,7 +12,32 @@ spec:
           containers:
           - name: {{ data.name }}
             image: {{ data.image }}:{{ tag | default("latest", true) }}
-            {%- if data.run %}
+
+            {%- if "env" in data %}
+            env:
+            {%- for env in data.env %}
+            - name: {{ env.name }}
+              {%- if "value" in env %}
+              value: "{{ env.value }}"
+              {%- endif %}
+
+              {%- if "secretKeyRef" in env %}
+              valueFrom:
+                secretKeyRef:
+                  key: {{ env.secretKeyRef.key }}
+                  name: {{ env.secretKeyRef.name }}
+              {%- endif %}
+
+              {%- if "configMapKeyRef" in env %}
+              valueFrom:
+                configMapKeyRef:
+                  key: {{ env.configMapKeyRef.key }}
+                  name: {{ env.configMapKeyRef.name }}
+              {%- endif %}
+            {%- endfor %}
+            {%- endif %}
+
+            {%- if "run" in data %}
             args:
             - /bin/sh
             - -c


### PR DESCRIPTION
# Done

- Modified cronjob template to support environment variables
- Add poller-script cronjob, every day at 5am

# QA
1. Run: `./konf.py --type CronJob production cronjobs/snapcraft-poller-script.yaml --local-qa | microk8s.kubectl apply -f -`
2. You should be able to see the CronJob running: `microk8s.kubectl get cronjob`
3. You should see used environment variables when doing: `microk8s.kubectl describe cronjob snapcraft-poller-script`
4. Don't forget to remove it: `microk8s.kubectl delete cronjob snapcraft-poller-script`