### PR TITLE
Snap up konf.py

### DIFF
--- a/create-project
+++ b/create-project
@@ -1,4 +1,4 @@
-#! /usr/bin/env python3
+#!/usr/bin/env python3
 
 import re
 import yaml

--- a/konf.py
+++ b/konf.py
@@ -1,9 +1,14 @@
-#! /usr/bin/env python3
+#!/usr/bin/env python3
 
 import argparse
+import os
 
 import jinja2
 import yaml
+
+
+BASE_DIR = os.getenv("SNAP", ".")
+TEMPLATES_DIR = BASE_DIR + "/templates"
 
 
 # Custom Jinja2 functions
@@ -68,7 +73,7 @@ class Konf:
         """Returns templates rendered."""
 
         # Init Jinja2 environment
-        template_loader = jinja2.FileSystemLoader("./templates")
+        template_loader = jinja2.FileSystemLoader(TEMPLATES_DIR)
         jinja_env = jinja2.Environment(
             loader=template_loader, undefined=jinja2.StrictUndefined
         )

--- a/qa-deploy
+++ b/qa-deploy
@@ -1,4 +1,4 @@
-#! /usr/bin/env bash
+#!/usr/bin/env bash
 
 # Bash strict mode
 set -eo pipefail

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,11 @@
+from setuptools import setup
+
+with open('requirements.txt') as f:
+    requirements = f.read().splitlines()
+
+setup(
+    name="konf",
+    version="0.1.0",
+    install_requires=requirements,
+    scripts=["konf.py"]
+)

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,23 @@
+name: konf
+base: core18
+version: '0.1'
+summary: K8s config generator
+description: K8s config generator
+grade: devel
+confinement: classic
+
+parts:
+  konf-src:
+    source: .
+    plugin: dump
+    stage:
+      - templates/
+    prime:
+      - templates/
+  konf-python:
+    source: .
+    plugin: python
+
+apps:
+  konf:
+    command: konf.py


### PR DESCRIPTION
## Done
Made `konf.py` a snap in preparation for us moving the configurations into each project repo.

## QA
- `snapcraft`
- `snap install --dangerous --classic konf_0.1_amd64.snap`
- `konf staging sites/ubuntu.com` and see it outputs the config.
- Try using the script directly too with `./konf.py`