### PR TITLE
Force secret key on template generation

### DIFF
--- a/sites/360.canonical.com.yaml
+++ b/sites/360.canonical.com.yaml
@@ -17,11 +17,6 @@ env:
       key: database_url
       name: threesixty-database-url
 
-  - name: SECRET_KEY
-    secretKeyRef:
-      key: secret_key
-      name: threesixty
-
 # Overrides for production
 production:
   replicas: 5

--- a/sites/anbox-cloud.io.yaml
+++ b/sites/anbox-cloud.io.yaml
@@ -6,11 +6,6 @@ env:
   - name: SENTRY_DSN
     value: https://37706e022f2841448dbb094990420522@sentry.is.canonical.com//23
 
-  - name: SECRET_KEY
-    secretKeyRef:
-      key: secret_key
-      name: anbox-cloud-io-secret
-
 production:
   replicas: 5
   nginxConfigurationSnippet: |

--- a/sites/charmhub.io.yaml
+++ b/sites/charmhub.io.yaml
@@ -3,11 +3,6 @@ domain: charmhub.io
 image: prod-comms.docker-registry.canonical.com/charmhub.io
 
 env:
-  - name: SECRET_KEY
-    secretKeyRef:
-      key: charmhub-io
-      name: secret-keys
-
   - name: SENTRY_DSN
     value: https://6cacb25de947478faeb57f3836da1cf3@sentry.is.canonical.com//24
 

--- a/sites/engage.canonical.com.yaml
+++ b/sites/engage.canonical.com.yaml
@@ -4,12 +4,6 @@ image: prod-comms.docker-registry.canonical.com/engage.canonical.com
 
 useProxy: false
 
-env:
-  - name: SECRET_KEY
-    secretKeyRef:
-      key: secret_key
-      name: prototype-secret-key
-
 # Overrides for production
 production:
   replicas: 2

--- a/sites/manager.assets.ubuntu.com.yaml
+++ b/sites/manager.assets.ubuntu.com.yaml
@@ -11,11 +11,6 @@ env:
       key: asset_server_token
       name: manager-assets-ubuntu-com
 
-  - name: SECRET_KEY
-    secretKeyRef:
-      key: secret_key
-      name: manager-assets-ubuntu-com
-
 # Overrides for production
 production:
   replicas: 2

--- a/sites/snapcraft.io.yaml
+++ b/sites/snapcraft.io.yaml
@@ -11,11 +11,6 @@ env:
       key: environment
       name: environment
 
-  - name: SECRET_KEY
-    secretKeyRef:
-      key: secret_key
-      name: snapcraft-io
-
   - name: MARKETO_CLIENT_ID
     secretKeyRef:
       key: marketo_client_id

--- a/sites/staging-api.snapcraft.io.yaml
+++ b/sites/staging-api.snapcraft.io.yaml
@@ -23,11 +23,6 @@ env:
       key: environment
       name: environment
 
-  - name: SECRET_KEY
-    secretKeyRef:
-      key: secret_key
-      name: snapcraft-io
-
   - name: MARKETO_CLIENT_ID
     secretKeyRef:
       key: marketo_client_id

--- a/sites/vanillaframework.io.yaml
+++ b/sites/vanillaframework.io.yaml
@@ -5,11 +5,6 @@ image: prod-comms.docker-registry.canonical.com/vanillaframework.io
 useProxy: false
 
 env:
-  - name: SECRET_KEY
-    secretKeyRef:
-      key: vanillaframework-io
-      name: secret-keys
-
   - name: SEARCH_API_KEY
     secretKeyRef:
       key: google-custom-search-key

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -24,6 +24,11 @@ spec:
             - name: TALISKER_NETWORKS
               value: 10.0.0.0/8
 
+            - name: SECRET_KEY
+              secretKeyRef:
+                key: {{ data.get('name') or get_site_name() }}
+                name: secret-keys
+
             {%- if data.useProxy is not defined or data.useProxy != False %}
             {% macro proxy_settings() %}{% include 'proxy-settings.yaml' %}{% endmacro %}
             {{ proxy_settings() | indent(12) }}


### PR DESCRIPTION
# Summary

For SECRET_KEY on template genreation.
From now on every deplooyement will have an env var SECRET_KEY set.

# QA

- ` ./konf.py production sites/conjure-up.io.yaml --tag test`
- Make sure there is a sercret key in the env var part.