### PR TITLE
Added IRC bot cronjobs

### DIFF
--- a/cronjobs/webteam-ircbot-review-notifier.yaml
+++ b/cronjobs/webteam-ircbot-review-notifier.yaml
@@ -1,0 +1,13 @@
+name: webteam-ircbot-review-notifier
+schedule: "0 9 * * 1-5"
+image: prod-comms.docker-registry.canonical.com/task-runner
+
+env:
+  - name: HUBOT_RELEASE_NOTIFICATION_SECRET
+    secretKeyRef:
+      key: hubot-release-notification-secret
+      name: irc-secrets
+
+run: |
+  curl --request POST -F "secret=$HUBOT_RELEASE_NOTIFICATION_SECRET" "https://webteam-ircbot.canonical.com/hubot/gh-pull-request-notification?rooms=%23web-team"
+  curl --request POST -F "secret=$HUBOT_RELEASE_NOTIFICATION_SECRET" "https://webteam-ircbot.canonical.com/hubot/gh-pull-request-notification?rooms=%23base-squad&authors=tbille,jkfran,jpmartinspt,nottrobin,carkod"

--- a/cronjobs/webteam-ircbot-support-updater.yaml
+++ b/cronjobs/webteam-ircbot-support-updater.yaml
@@ -1,0 +1,12 @@
+name: webteam-ircbot-support-updater
+schedule: "0 8 * * *"
+image: prod-comms.docker-registry.canonical.com/task-runner
+
+env:
+  - name: HUBOT_RELEASE_NOTIFICATION_SECRET
+    secretKeyRef:
+      key: hubot-release-notification-secret
+      name: irc-secrets
+
+run: |
+  curl --request POST -F "secret=$HUBOT_RELEASE_NOTIFICATION_SECRET" "https://webteam-ircbot.canonical.com/hubot/update-support?rooms=%23web-team"

--- a/templates/cronjob.yaml
+++ b/templates/cronjob.yaml
@@ -49,6 +49,7 @@ spec:
             args:
             - /bin/sh
             - -c
-            - {{ data.run }}
+            - |
+              {{ data.run | indent(14) }}
             {%- endif %}
           restartPolicy: Never


### PR DESCRIPTION
This change is to run our IRC notifications in our Kubernetes cluster instead of a GitHub Actions.

Please merge this commit at the same time that this one https://github.com/canonical-web-and-design/webteam-hubot/pull/62 to not send the notifications twice!