### PR TITLE
Add dqlite.io to no proxyy

### DIFF
--- a/templates/proxy-settings.yaml
+++ b/templates/proxy-settings.yaml
@@ -5,4 +5,4 @@
   value: "http://squid.internal:3128/"
 
 - name: NO_PROXY
-  value: "ubuntu.com,.ubuntu.com,snapcraft.io,.snapcraft.io,jujucharms.com,.jujucharms.com,maas.io,.maas.io,conjure-up.io,.conjure-up.io,netplan.io,.netplan.io,canonical.com,.canonical.com,launchpad.net,.launchpad.net,linuxcontainers.org,.linuxcontainers.org,cloud-init.io,.cloud-init.io,vanillaframework.io,.vanillaframework.io,anbox-cloud.io,.anbox-cloud.io,juju.is,.juju.is"
+  value: "ubuntu.com,.ubuntu.com,snapcraft.io,.snapcraft.io,jujucharms.com,.jujucharms.com,maas.io,.maas.io,conjure-up.io,.conjure-up.io,netplan.io,.netplan.io,canonical.com,.canonical.com,launchpad.net,.launchpad.net,linuxcontainers.org,.linuxcontainers.org,cloud-init.io,.cloud-init.io,vanillaframework.io,.vanillaframework.io,anbox-cloud.io,.anbox-cloud.io,juju.is,.juju.is,dqlite.io,.dqlite.io"


### PR DESCRIPTION
Add dqlite.io to no proxyy

- `./konf.py --local-qa staging sites/dqlite.io.yaml --tag test` 
- The line with `NO_PROXY` should have dqlite.io and .dqlite.io now