### PR TITLE
Konf strict snap

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,31 @@
+name: Tests
+on: pull_request
+
+jobs:
+  test-snap:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Install Snapcraft
+        run: sudo snap install snapcraft --classic
+
+      - name: Build Konf snap
+        run: /snap/bin/snapcraft --destructive-mode
+
+      - name: Install konf snap
+        run: sudo snap install --dangerous konf_*.snap
+
+  lint-python:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Install system dependencies
+        run: sudo pip3 install flake8 black
+
+      - name: Lint Python
+        run: flake8 . && black --line-length 79 --check .

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,11 @@
 from setuptools import setup
 
-with open('requirements.txt') as f:
+with open("requirements.txt") as f:
     requirements = f.read().splitlines()
 
 setup(
     name="konf",
-    version="0.1.0",
+    version="1.0.0",
     install_requires=requirements,
-    scripts=["konf.py"]
+    scripts=["konf.py"],
 )

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,23 +1,27 @@
 name: konf
 base: core18
-version: '0.1'
-summary: K8s config generator
-description: K8s config generator
-grade: devel
-confinement: classic
+
+version: "1.0.0"
+
+summary: Kubernetes template system for Canonical websites.
+
+description: |
+  A command-line tool to generate K8s configs
+  from Canonical's webteam
+grade: stable
+confinement: strict
+
+architectures:
+  - build-on: amd64
+    run-on: amd64
 
 parts:
-  konf-src:
-    source: .
-    plugin: dump
-    stage:
-      - templates/
-    prime:
-      - templates/
-  konf-python:
+  konf:
     source: .
     plugin: python
 
 apps:
   konf:
     command: konf.py
+    plugs:
+      - home


### PR DESCRIPTION
Changes to make a strict snap, this PR fixes https://github.com/canonical-web-and-design/snap-squad/issues/1336

# QA
Build the snap with:
`snapcraft`

Install the snap:
`snap install --dangerous konf_1.0.0_amd64.snap`

This should return the Kubernetes configuration for ubuntu.com:
`konf production sites/ubuntu.com.yaml --local-qa --tag test`