### PR TITLE
Fix Snap to include the templates folder

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: konf
 base: core18
 
-version: "1.0.0"
+version: git
 
 summary: Kubernetes template system for Canonical websites.
 
@@ -16,7 +16,14 @@ architectures:
     run-on: amd64
 
 parts:
-  konf:
+  konf-templates:
+    source: .
+    plugin: dump
+    stage:
+      - templates/
+    prime:
+      - templates/
+  konf-python:
     source: .
     plugin: python
 


### PR DESCRIPTION
The snap wasn't working properly because it didn't have the templates folder.

I also changed the version property to use git.

## QA
Build the snap with:
`snapcraft`

Install the snap:
`snap install --dangerous konf_1.0.0_amd64.snap`

This should return the Kubernetes configuration for ubuntu.com:
`konf production sites/ubuntu.com.yaml --local-qa --tag test`