### PR TITLE
Add partners site configuration

### DIFF
--- a/sites/partners.ubuntu.com.yaml
+++ b/sites/partners.ubuntu.com.yaml
@@ -1,0 +1,29 @@
+domain: partners.ubuntu.com
+image: prod-comms.docker-registry.canonical.com/partners.ubuntu.com
+
+production:
+  replicas: 5
+  env:
+    - name: SENTRY_DSN
+      value: https://063fdd4992a54aab90789b1306f18259@sentry.is.canonical.com//26
+
+    - name: DATABASE_URL
+      secretKeyRef:
+        key: database-url
+        name: partners-database-url
+
+  nginxConfigurationSnippet: |
+    if ($host != 'partners.ubuntu.com' ) {
+      rewrite ^ https://partners.ubuntu.com$request_uri? permanent;
+    }
+
+staging:
+  replicas: 2
+  env:
+    - name: DATABASE_URL
+      secretKeyRef:
+        key: database-url
+        name: partners-database-url
+
+  nginxConfigurationSnippet: |
+    more_set_headers "X-Robots-Tag: noindex";

--- a/sites/partners.ubuntu.com.yaml
+++ b/sites/partners.ubuntu.com.yaml
@@ -9,8 +9,8 @@ production:
 
     - name: DATABASE_URL
       secretKeyRef:
-        key: database-url
-        name: partners-database-url
+        name: database-urls
+        key: partners.ubuntu.com
 
   nginxConfigurationSnippet: |
     if ($host != 'partners.ubuntu.com' ) {
@@ -22,8 +22,8 @@ staging:
   env:
     - name: DATABASE_URL
       secretKeyRef:
-        key: database-url
-        name: partners-database-url
+        key: database-urls
+        name: partners.staging.ubuntu.com
 
   nginxConfigurationSnippet: |
     more_set_headers "X-Robots-Tag: noindex";


### PR DESCRIPTION
# Done

Fixes https://github.com/canonical-web-and-design/partners.ubuntu.com/issues/242
- Add partners.ubuntu.com configuration
- Add sentry https://sentry.is.canonical.com/canonical/partners-ubuntu-com/
- Secret keys added to secret in k8s
- **Not done**: 
  - added redirects to canonical.com/partners for url not part of: `(admin\/*|partners.json|customers.json|openid\/*)`
  - add database URL

# QA

- `./konf.py --local-qa staging sites/partners.ubuntu.com --tag test`
- `./konf.py --local-qa production sites/partners.ubuntu.com --tag test`
- Make sure configurations make sense