### PR TITLE
Charmhub: Add secret for SSO

### DIFF
--- a/sites/charmhub.io.yaml
+++ b/sites/charmhub.io.yaml
@@ -10,6 +10,9 @@ env:
   - name: CHARMSTORE_API_URL
     value: https://api.staging.snapcraft.io/
 
+  - name: LOGIN_LAUNCHPAD_TEAM
+    value: canonical
+
 # Overrides for production
 production:
   replicas: 5


### PR DESCRIPTION
This PR is to set the required Launchpad group to access charmhub.io