### PR TITLE
Proxy for microk8s installer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 env3
+.venv

--- a/sites/microk8s.io.yaml
+++ b/sites/microk8s.io.yaml
@@ -15,6 +15,11 @@ production:
       rewrite ^ https://microk8s.io$request_uri? permanent;
     }
     more_set_headers "Link: <https://assets.ubuntu.com>; rel=preconnect; crossorigin, <https://assets.ubuntu.com>; rel=preconnect";
+  nginxServerSnippet: |
+    location /install/ {
+      rewrite ^/install/(.*).exe /ubuntu/microk8s/releases/download/installer-$1/microk8s-installer.exe break;
+      proxy_pass https://github.com/;
+    }
 
 # Overrides for staging
 staging:
@@ -22,3 +27,8 @@ staging:
   nginxConfigurationSnippet: |
     more_set_headers "X-Robots-Tag: noindex";
     more_set_headers "Link: <https://assets.ubuntu.com>; rel=preconnect; crossorigin, <https://assets.ubuntu.com>; rel=preconnect";
+  nginxServerSnippet: |
+    location /install/ {
+      rewrite ^/install/(.*).exe /ubuntu/microk8s/releases/download/installer-$1/microk8s-installer.exe break;
+      proxy_pass https://github.com/;
+    }

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -11,6 +11,10 @@ metadata:
     nginx.ingress.kubernetes.io/configuration-snippet: |
       {{ data.nginxConfigurationSnippet | indent(6) }}
     {%- endif %}
+    {%- if "nginxServerSnippet" in data %}
+    nginx.ingress.kubernetes.io/server-snippet: |
+      {{ data.nginxServerSnippet | indent(6) }}
+    {%- endif %}
     {%- if data.nginxSSLRedirect is defined and not data.nginxSSLRedirect %}
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
     {%- endif %}


### PR DESCRIPTION
For https://github.com/canonical-web-and-design/microk8s.io/issues/280

Twinned with https://github.com/canonical-web-and-design/microk8s.io/pull/286

QA
--

```
./qa-deploy production sites/microk8s.io.yaml redirect-install
```

Add `127.0.0.1 microk8s.io` to `/etc/hosts`.

Open https://microk8s.io in a private window and trust the self-signed cert.

Now go to https://microk8s.io/install.exe and https://microk8s.io/install/v2.0.0.exe and see it serve you the installer!