### PR TITLE
CronJob for Snapcraft monthly stats email

### DIFF
--- a/cronjobs/snapcraft-monthly-stats-email.yaml
+++ b/cronjobs/snapcraft-monthly-stats-email.yaml
@@ -1,0 +1,9 @@
+name: snapcraft-monthly-stats-email
+schedule: "30 12 * * *"
+image: prod-comms.docker-registry.canonical.com/snapcraft-monthly-stats-email
+
+env:
+  - name: MARKETO_SECRET
+    secretKeyRef:
+      key: monthly-stats-email-marketo-secret
+      name: snapcraft-io


### PR DESCRIPTION
## Done

- Added new CronJob for Snapcraft monthly stats email (Fixes https://github.com/canonical-web-and-design/snap-squad/issues/1511)