### PR TITLE
Added Sentry DSN for snapcraft-monthly-stats-email cronjob

### DIFF
--- a/cronjobs/snapcraft-monthly-stats-email.yaml
+++ b/cronjobs/snapcraft-monthly-stats-email.yaml
@@ -3,6 +3,9 @@ schedule: "30 12 * * *"
 image: prod-comms.docker-registry.canonical.com/snapcraft-monthly-stats-email
 
 env:
+  - name: SENTRY_DSN
+    value: https://5f9288ae5c0d41379a913b03977b6e27@sentry.is.canonical.com//44
+
   - name: WEBTEAM_ACCOUNT_EMAIL
     secretKeyRef:
       key: snapcraft-account-email


### PR DESCRIPTION
Added Sentry DSN for snapcraft-monthly-stats-email cronjob, needed for https://github.com/canonical-web-and-design/snapcraft-monthly-stats-email/pull/11